### PR TITLE
Chapter 18: Types of Values

### DIFF
--- a/include/chunk.h
+++ b/include/chunk.h
@@ -16,22 +16,27 @@ typedef enum {
   OP_CONSTANT, /**< Loads a constant value with an 8-bit offset to the stack */
   OP_CONSTANT_LONG, /**< Loads a constant value with a 24-bit offset to the
                        stack */
-  OP_NIL,
-  OP_TRUE,
-  OP_FALSE,
-  OP_NOT,
-  OP_NEGATE,        /**< Negates the value at the top of the stack */
-  OP_EQUAL,
-  OP_NOT_EQUAL,
-  OP_GREATER,
-  OP_GTE,
-  OP_LESS,
-  OP_LTE,
-  OP_ADD,           /**< Adds the next two values in the stack */
-  OP_SUBTRACT,      /**< Subtracts the next two values in the stack */
-  OP_MULTIPLY,      /**< Multiplies the next two values in the stack */
-  OP_DIVIDE,        /**< Divides the next two values in the stack */
-  OP_RETURN         /**< Returns from the current function */
+  OP_NIL,           /**< Loads a nil value to the stack */
+  OP_TRUE,          /**< Loads a true boolean value to the stack */
+  OP_FALSE,         /**< Loads a false boolean value to the stack */
+  OP_NOT,    /**< Applies logical negation to the value at the top of the stack
+              */
+  OP_NEGATE, /**< Negates the value at the top of the stack */
+  OP_EQUAL,  /**< Compares the next two values in the stack using equality */
+  OP_NOT_EQUAL, /**< Compares the next two values in the stack using inequality
+                 */
+  OP_GREATER,   /**< Compares the next two values in the stack using "greater
+                   than" */
+  OP_GTE,  /**< Compares the next two values in the stack using "greater than or
+              equal to" */
+  OP_LESS, /**< Compares the next two values in the stack using "less than" */
+  OP_LTE,  /**< Compares the next two values in the stack using "less than or
+              equal to" */
+  OP_ADD,  /**< Adds the next two values in the stack */
+  OP_SUBTRACT, /**< Subtracts the next two values in the stack */
+  OP_MULTIPLY, /**< Multiplies the next two values in the stack */
+  OP_DIVIDE,   /**< Divides the next two values in the stack */
+  OP_RETURN    /**< Returns from the current function */
 } OpCode;
 
 /**

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -16,7 +16,17 @@ typedef enum {
   OP_CONSTANT, /**< Loads a constant value with an 8-bit offset to the stack */
   OP_CONSTANT_LONG, /**< Loads a constant value with a 24-bit offset to the
                        stack */
+  OP_NIL,
+  OP_TRUE,
+  OP_FALSE,
+  OP_NOT,
   OP_NEGATE,        /**< Negates the value at the top of the stack */
+  OP_EQUAL,
+  OP_NOT_EQUAL,
+  OP_GREATER,
+  OP_GTE,
+  OP_LESS,
+  OP_LTE,
   OP_ADD,           /**< Adds the next two values in the stack */
   OP_SUBTRACT,      /**< Subtracts the next two values in the stack */
   OP_MULTIPLY,      /**< Multiplies the next two values in the stack */

--- a/include/value.h
+++ b/include/value.h
@@ -46,6 +46,8 @@ typedef struct {
   Value* values;
 } ValueArray;
 
+bool valuesEqual(const Value a, const Value b);
+
 /**
  * \brief Initializes the resources of a given value array.
  *

--- a/include/value.h
+++ b/include/value.h
@@ -7,11 +7,34 @@
 
 #include "common.h"
 
+typedef enum {
+  VAL_BOOL,
+  VAL_NIL,
+  VAL_NUMBER,
+} ValueType;
+
 /**
  * \var Value
  * \brief Type definition for a constant value.
  */
-typedef double Value;
+typedef struct {
+  ValueType type;
+  union {
+    bool boolean;
+    double number;
+  } as;
+} Value;
+
+#define IS_BOOL(value) ((value).type == VAL_BOOL)
+#define IS_NIL(value) ((value).type == VAL_NIL)
+#define IS_NUMBER(value) ((value).type == VAL_NUMBER)
+
+#define AS_BOOL(value) ((value).as.boolean)
+#define AS_NUMBER(value) ((value).as.number)
+
+#define BOOL_VAL(value) ((Value){VAL_BOOL, {.boolean = value}})
+#define NIL_VAL ((Value){VAL_NIL, {.number = 0}})
+#define NUMBER_VAL(value) ((Value){VAL_NUMBER, {.number = value}})
 
 /**
  * \struct ValueArray

--- a/include/value.h
+++ b/include/value.h
@@ -7,33 +7,75 @@
 
 #include "common.h"
 
+/**
+ * \enum ValueType
+ * \brief Enum for all possible value types in Lox
+ */
 typedef enum {
-  VAL_BOOL,
-  VAL_NIL,
-  VAL_NUMBER,
+  VAL_BOOL,   /**< Boolean value */
+  VAL_NIL,    /**< Nil value */
+  VAL_NUMBER, /**< Numeric value */
 } ValueType;
 
 /**
- * \var Value
- * \brief Type definition for a constant value.
+ * \struct Value
+ * \brief Struct used to represent a value stored in the value stack
  */
 typedef struct {
-  ValueType type;
+  ValueType type; /**< Type of the value */
   union {
     bool boolean;
     double number;
-  } as;
+  } as; /**< Tagged union used to store the actual value with the appropriate
+           type */
 } Value;
 
+/**
+ * \def IS_BOOL(value)
+ * \brief Helper macro to determine if a Value is of type bool
+ */
 #define IS_BOOL(value) ((value).type == VAL_BOOL)
+
+/**
+ * \def IS_NIL(value)
+ * \brief Helper macro to determine if a Value is of type nil
+ */
 #define IS_NIL(value) ((value).type == VAL_NIL)
+
+/**
+ * \def IS_NUMBER(value)
+ * \brief Helper macro to determine if a Value is of type number
+ */
 #define IS_NUMBER(value) ((value).type == VAL_NUMBER)
 
+/**
+ * \def AS_BOOL(value)
+ * \brief Gets the stored Value as a boolean value
+ */
 #define AS_BOOL(value) ((value).as.boolean)
+
+/**
+ * \def AS_NUMBER(value)
+ * \brief Gets the stored Value as a numeric value
+ */
 #define AS_NUMBER(value) ((value).as.number)
 
+/**
+ * \def BOOL_VAL(value)
+ * \brief Creates a Value of type bool with a specified value
+ */
 #define BOOL_VAL(value) ((Value){VAL_BOOL, {.boolean = value}})
+
+/**
+ * \def NIL_VAL
+ * \brief Creates a Value of type nil
+ */
 #define NIL_VAL ((Value){VAL_NIL, {.number = 0}})
+
+/**
+ * \def NUMBER_VAL(value)
+ * \brief Creates a Value of type number with a specified value
+ */
 #define NUMBER_VAL(value) ((Value){VAL_NUMBER, {.number = value}})
 
 /**
@@ -46,6 +88,14 @@ typedef struct {
   Value* values;
 } ValueArray;
 
+/**
+ * \brief Determines if two Values are equal
+ *
+ * \param a First Value to be compared
+ * \param b Second Value to be compared
+ *
+ * \return Boolean value that indicates if the values are equal
+ */
 bool valuesEqual(const Value a, const Value b);
 
 /**

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -280,8 +280,8 @@ static void grouping() {
  *
  */
 static void number() {
-  Value value = strtod(parser.previous.start, NULL);
-  emitConstant(value);
+  double value = strtod(parser.previous.start, NULL);
+  emitConstant(NUMBER_VAL(value));
 }
 
 /**
@@ -354,7 +354,7 @@ ParseRule rules[] = {
  *
  * Based on the "rules" table, the function is able to determine if a token is
  * used as a prefix or as an infix within an expression.
- * 
+ *
  * \param precedence The lower bound for the precedence level of the expressions
  * that will be parsed
  *
@@ -378,7 +378,7 @@ static void parsePrecedence(Precedence precedence) {
 
 /**
  * \brief Obtains the parse rules for a token of a given type
- * 
+ *
  * \param type Token type whose rules must be fetched
  *
  */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -282,6 +282,10 @@ static void binary() {
   }
 }
 
+/**
+ * \brief Function to parse a literal expression
+ *
+ */
 static void literal() {
   switch (parser.previous.type) {
   case TOKEN_FALSE:

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -247,6 +247,24 @@ static void binary() {
   parsePrecedence((Precedence)(rule->precedence + 1));
 
   switch (operatorType) {
+  case TOKEN_BANG_EQUAL:
+    emitByte(OP_NOT_EQUAL);
+    break;
+  case TOKEN_EQUAL_EQUAL:
+    emitByte(OP_EQUAL);
+    break;
+  case TOKEN_GREATER:
+    emitByte(OP_GREATER);
+    break;
+  case TOKEN_GREATER_EQUAL:
+    emitByte(OP_GTE);
+    break;
+  case TOKEN_LESS:
+    emitByte(OP_LESS);
+    break;
+  case TOKEN_LESS_EQUAL:
+    emitByte(OP_LTE);
+    break;
   case TOKEN_PLUS:
     emitByte(OP_ADD);
     break;
@@ -261,6 +279,22 @@ static void binary() {
     break;
   default:
     return; // Unreachable.
+  }
+}
+
+static void literal() {
+  switch (parser.previous.type) {
+  case TOKEN_FALSE:
+    emitByte(OP_FALSE);
+    break;
+  case TOKEN_NIL:
+    emitByte(OP_NIL);
+    break;
+  case TOKEN_TRUE:
+    emitByte(OP_TRUE);
+    break;
+  default:
+    return; // Unreachable
   }
 }
 
@@ -295,6 +329,9 @@ static void unary() {
   parsePrecedence(PREC_UNARY);
 
   switch (operatorType) {
+  case TOKEN_BANG:
+    emitByte(OP_NOT);
+    break;
   case TOKEN_MINUS:
     emitByte(OP_NEGATE);
     break;
@@ -317,31 +354,31 @@ ParseRule rules[] = {
     [TOKEN_SEMICOLON] = {NULL, NULL, PREC_NONE},
     [TOKEN_SLASH] = {NULL, binary, PREC_FACTOR},
     [TOKEN_STAR] = {NULL, binary, PREC_FACTOR},
-    [TOKEN_BANG] = {NULL, NULL, PREC_NONE},
-    [TOKEN_BANG_EQUAL] = {NULL, NULL, PREC_NONE},
+    [TOKEN_BANG] = {unary, NULL, PREC_NONE},
+    [TOKEN_BANG_EQUAL] = {NULL, binary, PREC_EQUALITY},
     [TOKEN_EQUAL] = {NULL, NULL, PREC_NONE},
-    [TOKEN_EQUAL_EQUAL] = {NULL, NULL, PREC_NONE},
-    [TOKEN_GREATER] = {NULL, NULL, PREC_NONE},
-    [TOKEN_GREATER_EQUAL] = {NULL, NULL, PREC_NONE},
-    [TOKEN_LESS] = {NULL, NULL, PREC_NONE},
-    [TOKEN_LESS_EQUAL] = {NULL, NULL, PREC_NONE},
+    [TOKEN_EQUAL_EQUAL] = {NULL, binary, PREC_EQUALITY},
+    [TOKEN_GREATER] = {NULL, binary, PREC_COMPARISON},
+    [TOKEN_GREATER_EQUAL] = {NULL, binary, PREC_COMPARISON},
+    [TOKEN_LESS] = {NULL, binary, PREC_COMPARISON},
+    [TOKEN_LESS_EQUAL] = {NULL, binary, PREC_COMPARISON},
     [TOKEN_IDENTIFIER] = {NULL, NULL, PREC_NONE},
     [TOKEN_STRING] = {NULL, NULL, PREC_NONE},
     [TOKEN_NUMBER] = {number, NULL, PREC_NONE},
     [TOKEN_AND] = {NULL, NULL, PREC_NONE},
     [TOKEN_CLASS] = {NULL, NULL, PREC_NONE},
     [TOKEN_ELSE] = {NULL, NULL, PREC_NONE},
-    [TOKEN_FALSE] = {NULL, NULL, PREC_NONE},
+    [TOKEN_FALSE] = {literal, NULL, PREC_NONE},
     [TOKEN_FOR] = {NULL, NULL, PREC_NONE},
     [TOKEN_FUN] = {NULL, NULL, PREC_NONE},
     [TOKEN_IF] = {NULL, NULL, PREC_NONE},
-    [TOKEN_NIL] = {NULL, NULL, PREC_NONE},
+    [TOKEN_NIL] = {literal, NULL, PREC_NONE},
     [TOKEN_OR] = {NULL, NULL, PREC_NONE},
     [TOKEN_PRINT] = {NULL, NULL, PREC_NONE},
     [TOKEN_RETURN] = {NULL, NULL, PREC_NONE},
     [TOKEN_SUPER] = {NULL, NULL, PREC_NONE},
     [TOKEN_THIS] = {NULL, NULL, PREC_NONE},
-    [TOKEN_TRUE] = {NULL, NULL, PREC_NONE},
+    [TOKEN_TRUE] = {literal, NULL, PREC_NONE},
     [TOKEN_VAR] = {NULL, NULL, PREC_NONE},
     [TOKEN_WHILE] = {NULL, NULL, PREC_NONE},
     [TOKEN_ERROR] = {NULL, NULL, PREC_NONE},

--- a/src/debug.c
+++ b/src/debug.c
@@ -88,8 +88,28 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return constantInstruction("OP_CONSTANT", chunk, offset);
   case OP_CONSTANT_LONG:
     return constantLongInstruction("OP_CONSTANT_LONG", chunk, offset);
+  case OP_NIL:
+    return simpleInstruction("OP_NIL", offset);
+  case OP_TRUE:
+    return simpleInstruction("OP_TRUE", offset);
+  case OP_FALSE:
+    return simpleInstruction("OP_FALSE", offset);
+  case OP_NOT:
+    return simpleInstruction("OP_NOT", offset);
   case OP_NEGATE:
     return simpleInstruction("OP_NEGATE", offset);
+  case OP_EQUAL:
+    return simpleInstruction("OP_EQUAL", offset);
+  case OP_NOT_EQUAL:
+    return simpleInstruction("OP_NOT_EQUAL", offset);
+  case OP_GREATER:
+    return simpleInstruction("OP_GREATER", offset);
+  case OP_GTE:
+    return simpleInstruction("OP_GTE", offset);
+  case OP_LESS:
+    return simpleInstruction("OP_LESS", offset);
+  case OP_LTE:
+    return simpleInstruction("OP_LTE", offset);
   case OP_ADD:
     return simpleInstruction("OP_ADD", offset);
   case OP_SUBTRACT:

--- a/src/value.c
+++ b/src/value.c
@@ -29,5 +29,5 @@ void freeValueArray(ValueArray* array) {
 }
 
 void printValue(const Value value) {
-  printf("%g", value);
+  printf("%g", AS_NUMBER(value));
 }

--- a/src/value.c
+++ b/src/value.c
@@ -29,5 +29,33 @@ void freeValueArray(ValueArray* array) {
 }
 
 void printValue(const Value value) {
-  printf("%g", AS_NUMBER(value));
+  switch (value.type) {
+  case VAL_BOOL:
+    printf(AS_BOOL(value) ? "true" : "false");
+    break;
+  case VAL_NIL:
+    printf("nil");
+    break;
+  case VAL_NUMBER:
+    printf("%g", AS_NUMBER(value));
+    break;
+  default:
+    break;
+  }
+}
+
+bool valuesEqual(const Value a, const Value b) {
+  if (a.type != b.type)
+    return false;
+  
+  switch (a.type) {
+  case VAL_BOOL:
+    return AS_BOOL(a) == AS_BOOL(b);
+  case VAL_NIL:
+    return true;
+  case VAL_NUMBER:
+    return AS_NUMBER(a) == AS_NUMBER(b);
+  default:
+    return false; // Unreachable
+  }
 }

--- a/src/value.c
+++ b/src/value.c
@@ -47,7 +47,7 @@ void printValue(const Value value) {
 bool valuesEqual(const Value a, const Value b) {
   if (a.type != b.type)
     return false;
-  
+
   switch (a.type) {
   case VAL_BOOL:
     return AS_BOOL(a) == AS_BOOL(b);

--- a/src/vm.c
+++ b/src/vm.c
@@ -50,8 +50,12 @@ Value pop() {
   return *vm.stackTop;
 }
 
-static Value peek(int distance) {
+static Value peek(const int32_t distance) {
   return vm.stackTop[-1 - distance];
+}
+
+static bool isFalsey(const Value value) {
+  return IS_NIL(value) || (IS_BOOL(value) && !AS_BOOL(value));
 }
 
 /**
@@ -115,6 +119,18 @@ static InterpretResult run() {
       push(constant);
       break;
     }
+    case OP_NIL:
+      push(NIL_VAL);
+      break;
+    case OP_TRUE:
+      push(BOOL_VAL(true));
+      break;
+    case OP_FALSE:
+      push(BOOL_VAL(false));
+      break;
+    case OP_NOT:
+      vm.stackTop[-1] = BOOL_VAL(isFalsey(vm.stackTop[-1]));
+      break;
     case OP_NEGATE:
       if (!IS_NUMBER(peek(0))) {
         runtimeError("Operand must be a number.");
@@ -122,6 +138,30 @@ static InterpretResult run() {
       }
 
       vm.stackTop[-1] = NUMBER_VAL(-AS_NUMBER(vm.stackTop[-1]));
+      break;
+    case OP_EQUAL: {
+      Value left = pop();
+      Value right = pop();
+      push(BOOL_VAL(valuesEqual(left, right)));
+      break;
+    }
+    case OP_NOT_EQUAL: {
+      Value left = pop();
+      Value right = pop();
+      push(BOOL_VAL(!valuesEqual(left, right)));
+      break;
+    }
+    case OP_GREATER:
+      BINARY_OP(BOOL_VAL, >);
+      break;
+    case OP_GTE:
+      BINARY_OP(BOOL_VAL, >=);
+      break;
+    case OP_LESS:
+      BINARY_OP(BOOL_VAL, <);
+      break;
+    case OP_LTE:
+      BINARY_OP(BOOL_VAL, <=);
       break;
     case OP_ADD:
       BINARY_OP(NUMBER_VAL, +);

--- a/src/vm.c
+++ b/src/vm.c
@@ -21,6 +21,13 @@ static void resetStack() {
   vm.stackTop = vm.stack;
 }
 
+/**
+ * \brief Variadic function used to report a runtime error in the appropriate
+ * line
+ *
+ * \param format Format string for the error message
+ * \param ... Arguments for format specification
+ */
 static void runtimeError(const char* format, ...) {
   va_list args;
   va_start(args, format);
@@ -50,12 +57,27 @@ Value pop() {
   return *vm.stackTop;
 }
 
+/**
+ * \brief Returns the value at a certain distance in the stack without popping
+ * it
+ *
+ * \param distance How far down the stack the target the desired value is
+ *
+ * \return The peeked Value
+ */
 static Value peek(const int32_t distance) {
   return vm.stackTop[-1 - distance];
 }
 
+/**
+ * \brief Returns whether a Value is falsey or not
+ *
+ * \param value The Value in consideration
+ *
+ * \return Boolean value that indicates if the parameter is falsey
+ */
 static bool isFalsey(const Value value) {
-  return IS_NIL(value) || (IS_BOOL(value) && !AS_BOOL(value));
+  return IS_NIL(value) || (IS_BOOL(value) && AS_BOOL(value) == false);
 }
 
 /**
@@ -77,7 +99,8 @@ static InterpretResult run() {
   (vm.chunk->constants                                                         \
        .values[READ_BYTE() | ((READ_BYTE()) << 8) | ((READ_BYTE()) << 16)])
 
-// Apply a binary operation based on the two next values at stack
+// Apply a binary operation based on the two next values at stack and on the
+// type of the operands
 #define BINARY_OP(valueType, op)                                               \
   do {                                                                         \
     if (!IS_NUMBER(peek(0)) || !IS_NUMBER(peek(1))) {                          \


### PR DESCRIPTION
This PR implements [chapter 18](https://craftinginterpreters.com/types-of-values.html) of Crafting Interpreters.

Unlike the original code, my implementation adds one bytecode instruction per logical operation. Therefore, there are three additional opcodes:
- OP_NOT_EQUAL
- OP_GTE
- OP_LTE