### PR TITLE
Chapter 21: Global Variables

### DIFF
--- a/include/chunk.h
+++ b/include/chunk.h
@@ -19,13 +19,19 @@ typedef enum {
   OP_NIL,           /**< Loads a nil value to the stack */
   OP_TRUE,          /**< Loads a true boolean value to the stack */
   OP_FALSE,         /**< Loads a false boolean value to the stack */
-  OP_POP,
-  OP_GET_GLOBAL,
-  OP_GET_GLOBAL_LONG,
-  OP_DEFINE_GLOBAL,
-  OP_DEFINE_GLOBAL_LONG,
-  OP_SET_GLOBAL,
-  OP_SET_GLOBAL_LONG,
+  OP_POP,           /**< Pops a value from the stack */
+  OP_GET_GLOBAL, /**< Loads a global variable to the stack with an 8-bit offset
+                  */
+  OP_GET_GLOBAL_LONG, /**< Loads a global variable to the stack with a 24-bit
+                         offset */
+  OP_DEFINE_GLOBAL,   /**< Defines a new global variable variable with an 8-bit
+                         offset */
+  OP_DEFINE_GLOBAL_LONG, /**< Defines a new global variable variable with a
+                            24-bit offset */
+  OP_SET_GLOBAL, /**< Updates the value of a defined global variable with an
+                    8-bit offset */
+  OP_SET_GLOBAL_LONG, /**< Updates the value of a defined global variable with a
+                         24-bit offset */
   OP_NOT,    /**< Applies logical negation to the value at the top of the stack
               */
   OP_NEGATE, /**< Negates the value at the top of the stack */

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -19,6 +19,13 @@ typedef enum {
   OP_NIL,           /**< Loads a nil value to the stack */
   OP_TRUE,          /**< Loads a true boolean value to the stack */
   OP_FALSE,         /**< Loads a false boolean value to the stack */
+  OP_POP,
+  OP_GET_GLOBAL,
+  OP_GET_GLOBAL_LONG,
+  OP_DEFINE_GLOBAL,
+  OP_DEFINE_GLOBAL_LONG,
+  OP_SET_GLOBAL,
+  OP_SET_GLOBAL_LONG,
   OP_NOT,    /**< Applies logical negation to the value at the top of the stack
               */
   OP_NEGATE, /**< Negates the value at the top of the stack */
@@ -36,7 +43,8 @@ typedef enum {
   OP_SUBTRACT, /**< Subtracts the next two values in the stack */
   OP_MULTIPLY, /**< Multiplies the next two values in the stack */
   OP_DIVIDE,   /**< Divides the next two values in the stack */
-  OP_RETURN    /**< Returns from the current function */
+  OP_PRINT,
+  OP_RETURN /**< Returns from the current function */
 } OpCode;
 
 /**
@@ -109,6 +117,6 @@ uint32_t getLine(const Chunk* chunk, const size_t instructionOffset);
  *
  * \return The offset of the constant in the chunk's constants array
  */
-size_t addConstant(Chunk* chunk, const Value value);
+uint32_t addConstant(Chunk* chunk, const Value value);
 
 #endif

--- a/include/global.h
+++ b/include/global.h
@@ -1,0 +1,25 @@
+#ifndef CLOX_GLOBAL_H
+#define CLOX_GLOBAL_H
+
+#include "common.h"
+#include "object.h"
+#include "value.h"
+
+typedef struct {
+  ObjString* identifier;
+  Value value;
+} GlobalVar;
+
+typedef struct {
+  size_t capacity;
+  size_t count;
+  GlobalVar* vars;
+} GlobalVarArray;
+
+#define UNDEFINED_GLOBAL(identifier) ((GlobalVar){identifier, UNDEFINED_VAL})
+
+void initGlobalVarArray(GlobalVarArray* array);
+void freeGlobalVarArray(GlobalVarArray* array);
+void writeGlobalVarArray(GlobalVarArray* array, const GlobalVar var);
+
+#endif

--- a/include/global.h
+++ b/include/global.h
@@ -1,3 +1,7 @@
+/*! \file global.h
+    \brief Functions and data types for handling the storage of global variables
+*/
+
 #ifndef CLOX_GLOBAL_H
 #define CLOX_GLOBAL_H
 
@@ -5,21 +9,52 @@
 #include "object.h"
 #include "value.h"
 
+/**
+ * \struct GlobalVar
+ * \brief Strucure that represents a global variable.
+ */
 typedef struct {
-  ObjString* identifier;
-  Value value;
+  ObjString* identifier; /**< The variable's identifier */
+  Value value;           /**< The value of the variable */
 } GlobalVar;
 
+/**
+ * \struct GlobalVarArray
+ * \brief Strucure that contains an array of global variable values and its
+ * metadata.
+ */
 typedef struct {
-  size_t capacity;
-  size_t count;
-  GlobalVar* vars;
+  size_t capacity; /**< The number of values in the array */
+  size_t count;    /**< The current capacity of the array */
+  GlobalVar* vars; /**< Pointer to the global values in memory */
 } GlobalVarArray;
 
+/**
+ * \def UNDEFINED_GLOBAL(identifier)
+ * \brief Helper that creates an uninitialized global variable
+ */
 #define UNDEFINED_GLOBAL(identifier) ((GlobalVar){identifier, UNDEFINED_VAL})
 
+/**
+ * \brief Initializes the resources of a given global values array.
+ *
+ * \param array Array to be initialized
+ */
 void initGlobalVarArray(GlobalVarArray* array);
+
+/**
+ * \brief Frees the resources of a given array.
+ *
+ * \param array Array to be freed
+ */
 void freeGlobalVarArray(GlobalVarArray* array);
+
+/**
+ * \brief Adds a value to a given array.
+ *
+ * \param array Array where the value will be inserted
+ * \param var Global value that will be added to \p array
+ */
 void writeGlobalVarArray(GlobalVarArray* array, const GlobalVar var);
 
 #endif

--- a/include/value.h
+++ b/include/value.h
@@ -118,12 +118,12 @@ typedef struct {
 
 /**
  * \struct ValueArray
- * \brief  Strucure that contains a array of constant values and its metadata.
+ * \brief  Strucure that contains an array of constant values and its metadata.
  */
 typedef struct {
-  size_t count;
-  size_t capacity;
-  Value* values;
+  size_t count;    /**< The number of values in the array */
+  size_t capacity; /**< The current capacity of the array */
+  Value* values;   /**< Pointer to the values in memory */
 } ValueArray;
 
 /**

--- a/include/value.h
+++ b/include/value.h
@@ -17,10 +17,11 @@ typedef struct ObjString ObjString;
  * \brief Enum for all possible value types in Lox
  */
 typedef enum {
-  VAL_BOOL,   /**< Boolean value */
-  VAL_NIL,    /**< Nil value */
-  VAL_NUMBER, /**< Numeric value */
-  VAL_OBJ     /**< Heap-allocated value */
+  VAL_BOOL,     /**< Boolean value */
+  VAL_NIL,      /**< Nil value */
+  VAL_NUMBER,   /**< Numeric value */
+  VAL_OBJ,      /**< Heap-allocated value */
+  VAL_UNDEFINED /**< Internal use only. Represents a non-initialized variable */
 } ValueType;
 
 /**
@@ -60,6 +61,12 @@ typedef struct {
  * \brief Helper macro to determine if a Value is of type object
  */
 #define IS_OBJ(value) ((value).type == VAL_OBJ)
+
+/**
+ * \def IS_UNDEFINED(value)
+ * \brief Helper macro to determine if the type of a Value variable is VAL_UNDEF
+ */
+#define IS_UNDEFINED(value) ((value).type == VAL_UNDEFINED)
 
 /**
  * \def AS_BOOL(value)
@@ -102,6 +109,12 @@ typedef struct {
  * \brief Creates a Value of type object with a specified object pointer
  */
 #define OBJ_VAL(object) ((Value){VAL_OBJ, {.obj = (Obj*)object}})
+
+/**
+ * \def UNDEFINED_VAL(value)
+ * \brief Creates a Value of type object with a specified object pointer
+ */
+#define UNDEFINED_VAL ((Value){VAL_UNDEFINED, {.number = 0}})
 
 /**
  * \struct ValueArray

--- a/include/vm.h
+++ b/include/vm.h
@@ -25,6 +25,7 @@ typedef struct {
   uint8_t* ip;            /**< Pointer to the next instruction to be executed */
   Value stack[STACK_MAX]; /**< Value stack used to manage temporary values */
   Value* stackTop;        /**< Pointer to the top of the stack */
+  Table globals;
   Table strings; /**< Table of allocated strings, used for string interning */
   Obj* objects;  /**< Pointer to the head of the linked-list of heap-allocated
                     objects */

--- a/include/vm.h
+++ b/include/vm.h
@@ -6,9 +6,9 @@
 #define CLOX_VM_H
 
 #include "chunk.h"
+#include "global.h"
 #include "table.h"
 #include "value.h"
-#include "global.h"
 
 /**
  * \def STACK_MAX
@@ -26,8 +26,8 @@ typedef struct {
   uint8_t* ip;            /**< Pointer to the next instruction to be executed */
   Value stack[STACK_MAX]; /**< Value stack used to manage temporary values */
   Value* stackTop;        /**< Pointer to the top of the stack */
-  Table globalNames;
-  GlobalVarArray globalValues;
+  Table globalNames;      /**< Table of defined global identifiers */
+  GlobalVarArray globalValues; /**< Array with values of global variables */
   Table strings; /**< Table of allocated strings, used for string interning */
   Obj* objects;  /**< Pointer to the head of the linked-list of heap-allocated
                     objects */

--- a/include/vm.h
+++ b/include/vm.h
@@ -8,6 +8,7 @@
 #include "chunk.h"
 #include "table.h"
 #include "value.h"
+#include "global.h"
 
 /**
  * \def STACK_MAX
@@ -25,7 +26,8 @@ typedef struct {
   uint8_t* ip;            /**< Pointer to the next instruction to be executed */
   Value stack[STACK_MAX]; /**< Value stack used to manage temporary values */
   Value* stackTop;        /**< Pointer to the top of the stack */
-  Table globals;
+  Table globalNames;
+  GlobalVarArray globalValues;
   Table strings; /**< Table of allocated strings, used for string interning */
   Obj* objects;  /**< Pointer to the head of the linked-list of heap-allocated
                     objects */

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -76,5 +76,5 @@ uint32_t getLine(const Chunk* chunk, const size_t instructionOffset) {
 uint32_t addConstant(Chunk* chunk, const Value value) {
   writeValueArray(&chunk->constants, value);
 
-  return chunk->constants.count - 1;
+  return (uint32_t)chunk->constants.count - 1;
 }

--- a/src/chunk.c
+++ b/src/chunk.c
@@ -73,7 +73,7 @@ uint32_t getLine(const Chunk* chunk, const size_t instructionOffset) {
   }
 }
 
-size_t addConstant(Chunk* chunk, const Value value) {
+uint32_t addConstant(Chunk* chunk, const Value value) {
   writeValueArray(&chunk->constants, value);
 
   return chunk->constants.count - 1;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -562,6 +562,8 @@ static void synchronize() {
     default:
       break;
     }
+
+    advance();
   }
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -31,9 +31,10 @@ static size_t simpleInstruction(const char* name, const size_t offset) {
 
 /**
  * \brief Display an OP_CONSTANT instruction at a given offset. This instruction
- * has one 8-bit operand
+ * has one 8-bit operand.
  *
  * \param name Name of the instruction
+ * \param chunk Pointer to the chunk of bytecode that contains the instruction
  * \param offset Offset of the instruction within the bytecode array
  *
  * \return Offset of the next instruction
@@ -54,6 +55,7 @@ static size_t constantInstruction(const char* name, const Chunk* chunk,
  * instruction has three 8-bit operands.
  *
  * \param name Name of the instruction
+ * \param chunk Pointer to the chunk of bytecode that contains the instruction
  * \param offset Offset of the instruction within the bytecode array
  *
  * \return Offset of the next instruction
@@ -72,7 +74,18 @@ static size_t constantLongInstruction(const char* name, const Chunk* chunk,
   return offset + 4;
 }
 
-static size_t globalOffsetInstruction(const char* name, const Chunk* chunk, const size_t offset) {
+/**
+ * \brief Display an instruction which handles global variables. This
+ * instruction has one 8-bit operand.
+ *
+ * \param name Name of the instruction
+ * \param chunk Pointer to the chunk of bytecode that contains the instruction
+ * \param offset Offset of the instruction within the bytecode array
+ *
+ * \return Offset of the next instruction
+ */
+static size_t globalInstruction(const char* name, const Chunk* chunk,
+                                const size_t offset) {
   uint8_t globalOffset = chunk->code[offset + 1];
 
   printf("%-16s %4d '", name, globalOffset);
@@ -82,10 +95,21 @@ static size_t globalOffsetInstruction(const char* name, const Chunk* chunk, cons
   return offset + 2;
 }
 
-static size_t globalLongOffsetInstruction(const char* name, const Chunk* chunk, const size_t offset) {
+/**
+ * \brief Display an instruction which handles global variables. This
+ * instruction has three 8-bit operands.
+ *
+ * \param name Name of the instruction
+ * \param chunk Pointer to the chunk of bytecode that contains the instruction
+ * \param offset Offset of the instruction within the bytecode array
+ *
+ * \return Offset of the next instruction
+ */
+static size_t globalLongInstruction(const char* name, const Chunk* chunk,
+                                    const size_t offset) {
   uint32_t globalOffset = (chunk->code[offset + 3] << 16) |
-                            (chunk->code[offset + 2] << 8) |
-                            chunk->code[offset + 1];
+                          (chunk->code[offset + 2] << 8) |
+                          chunk->code[offset + 1];
 
   printf("%-16s %4d '", name, globalOffset);
   printValue(vm.globalValues.vars[globalOffset].value);
@@ -120,17 +144,17 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
   case OP_POP:
     return simpleInstruction("OP_POP", offset);
   case OP_GET_GLOBAL:
-    return globalOffsetInstruction("OP_GET_GLOBAL", chunk, offset);
+    return globalInstruction("OP_GET_GLOBAL", chunk, offset);
   case OP_GET_GLOBAL_LONG:
-    return globalLongOffsetInstruction("OP_GET_GLOBAL_LONG", chunk, offset);
+    return globalLongInstruction("OP_GET_GLOBAL_LONG", chunk, offset);
   case OP_DEFINE_GLOBAL:
-    return globalOffsetInstruction("OP_DEFINE_GLOBAL", chunk, offset);
+    return globalInstruction("OP_DEFINE_GLOBAL", chunk, offset);
   case OP_DEFINE_GLOBAL_LONG:
-    return globalLongOffsetInstruction("OP_DEFINE_GLOBAL_LONG", chunk, offset);
+    return globalLongInstruction("OP_DEFINE_GLOBAL_LONG", chunk, offset);
   case OP_SET_GLOBAL:
-    return globalOffsetInstruction("OP_SET_GLOBAL", chunk, offset);
+    return globalInstruction("OP_SET_GLOBAL", chunk, offset);
   case OP_SET_GLOBAL_LONG:
-    return globalLongOffsetInstruction("OP_SET_GLOBAL_LONG", chunk, offset);
+    return globalLongInstruction("OP_SET_GLOBAL_LONG", chunk, offset);
   case OP_NOT:
     return simpleInstruction("OP_NOT", offset);
   case OP_NEGATE:

--- a/src/debug.c
+++ b/src/debug.c
@@ -48,6 +48,18 @@ static size_t constantInstruction(const char* name, const Chunk* chunk,
   return offset + 2;
 }
 
+static size_t globalOffsetInstruction(const char* name, const size_t offset) {
+  printf("%-16s %4ld\n", name, offset);
+
+  return offset + 2;
+}
+
+static size_t globalLongOffsetInstruction(const char* name, const size_t offset) {
+  printf("%-16s %4ld\n", name, offset);
+
+  return offset + 4;
+}
+
 /**
  * \brief Display an OP_CONSTANT_LONG instruction at a given offset. This
  * instruction has three 8-bit operands.
@@ -97,17 +109,17 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
   case OP_POP:
     return simpleInstruction("OP_POP", offset);
   case OP_GET_GLOBAL:
-    return constantInstruction("OP_GET_GLOBAL", chunk, offset);
+    return globalOffsetInstruction("OP_GET_GLOBAL", offset);
   case OP_GET_GLOBAL_LONG:
-    return constantLongInstruction("OP_GET_GLOBAL_LONG", chunk, offset);
+    return globalLongOffsetInstruction("OP_GET_GLOBAL_LONG", offset);
   case OP_DEFINE_GLOBAL:
-    return constantInstruction("OP_DEFINE_GLOBAL", chunk, offset);
+    return globalOffsetInstruction("OP_DEFINE_GLOBAL", offset);
   case OP_DEFINE_GLOBAL_LONG:
-    return constantLongInstruction("OP_DEFINE_GLOBAL_LONG", chunk, offset);
+    return globalLongOffsetInstruction("OP_DEFINE_GLOBAL_LONG", offset);
   case OP_SET_GLOBAL:
-    return constantInstruction("OP_SET_GLOBAL", chunk, offset);
+    return globalOffsetInstruction("OP_SET_GLOBAL", offset);
   case OP_SET_GLOBAL_LONG:
-    return constantLongInstruction("OP_SET_GLOBAL_LONG", chunk, offset);
+    return globalLongOffsetInstruction("OP_SET_GLOBAL_LONG", offset);
   case OP_NOT:
     return simpleInstruction("OP_NOT", offset);
   case OP_NEGATE:

--- a/src/debug.c
+++ b/src/debug.c
@@ -94,6 +94,20 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return simpleInstruction("OP_TRUE", offset);
   case OP_FALSE:
     return simpleInstruction("OP_FALSE", offset);
+  case OP_POP:
+    return simpleInstruction("OP_POP", offset);
+  case OP_GET_GLOBAL:
+    return constantInstruction("OP_GET_GLOBAL", chunk, offset);
+  case OP_GET_GLOBAL_LONG:
+    return constantLongInstruction("OP_GET_GLOBAL_LONG", chunk, offset);
+  case OP_DEFINE_GLOBAL:
+    return constantInstruction("OP_DEFINE_GLOBAL", chunk, offset);
+  case OP_DEFINE_GLOBAL_LONG:
+    return constantLongInstruction("OP_DEFINE_GLOBAL_LONG", chunk, offset);
+  case OP_SET_GLOBAL:
+    return constantInstruction("OP_SET_GLOBAL", chunk, offset);
+  case OP_SET_GLOBAL_LONG:
+    return constantLongInstruction("OP_SET_GLOBAL_LONG", chunk, offset);
   case OP_NOT:
     return simpleInstruction("OP_NOT", offset);
   case OP_NEGATE:
@@ -118,6 +132,8 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return simpleInstruction("OP_MULTIPLY", offset);
   case OP_DIVIDE:
     return simpleInstruction("OP_DIVIDE", offset);
+  case OP_PRINT:
+    return simpleInstruction("OP_PRINT", offset);
   case OP_RETURN:
     return simpleInstruction("OP_RETURN", offset);
   default:

--- a/src/global.c
+++ b/src/global.c
@@ -1,3 +1,7 @@
+/*! \file global.c
+    \brief Definitions of functions from global.h
+*/
+
 #include "global.h"
 #include "memory.h"
 

--- a/src/global.c
+++ b/src/global.c
@@ -1,0 +1,25 @@
+#include "global.h"
+#include "memory.h"
+
+void initGlobalVarArray(GlobalVarArray* array) {
+  array->count = 0;
+  array->capacity = 0;
+  array->vars = NULL;
+}
+
+void freeGlobalVarArray(GlobalVarArray* array) {
+  FREE_ARRAY(GlobalVar, array->vars, array->capacity);
+  initGlobalVarArray(array);
+}
+
+void writeGlobalVarArray(GlobalVarArray* array, const GlobalVar var) {
+  if (array->capacity <= array->count) {
+    size_t oldCapacity = array->capacity;
+    array->capacity = GROW_CAPACITY(oldCapacity);
+    array->vars =
+        GROW_ARRAY(GlobalVar, array->vars, oldCapacity, array->capacity);
+  }
+
+  array->vars[array->count] = var;
+  ++array->count;
+}

--- a/src/table.c
+++ b/src/table.c
@@ -101,7 +101,7 @@ bool tableGet(const Table* table, const ObjString* key, Value* value) {
     return false;
 
   Entry* entry = findEntry(table->entries, table->capacity, key);
-  if (entry == NULL)
+  if (entry->key == NULL)
     return false;
 
   *value = entry->value;

--- a/src/table.c
+++ b/src/table.c
@@ -9,6 +9,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+/**
+ * \def TABLE_MAX_LOAD
+ * \brief Maximum load factor that a table can have before having its capacity
+ * adjusted
+ */
 #define TABLE_MAX_LOAD 0.75
 
 void initTable(Table* table) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -114,6 +114,16 @@ static void concatenate() {
   push(OBJ_VAL(concatenatedString));
 }
 
+/**
+ * \brief Auxiliary function that gets the value of global variable based on its
+ * offset in the globalValues array. The value is pushed to the stack.
+ *
+ * \param offset The offset of the variable in the globalValues array
+ *
+ * \return Boolean value that indicates if there were any errors when fetching
+ * the variable
+ *
+ */
 static bool getGlobal(const uint32_t offset) {
   GlobalVar var = vm.globalValues.vars[offset];
 
@@ -126,10 +136,24 @@ static bool getGlobal(const uint32_t offset) {
   return true;
 }
 
+/**
+ * \brief Auxiliary function that defines a global variable by setting its
+ * value.
+ *
+ * \param offset The offset of the variable in the globalValues array
+ */
 static void defineGlobal(const uint32_t offset) {
   vm.globalValues.vars[offset].value = pop();
 }
 
+/**
+ * \brief Auxiliary function that sets the value of a global variable only if it
+ * has already been defined.
+ *
+ * \param offset The offset of the variable in the globalValues array
+ *
+ * \return Boolean value that indicates if there were any errors
+ */
 static bool setGlobal(const uint32_t offset) {
   GlobalVar* var = vm.globalValues.vars + offset;
 
@@ -148,9 +172,10 @@ static bool setGlobal(const uint32_t offset) {
  * \return Result of the interpretation process
  */
 static InterpretResult run() {
-// Read a single bytecode from the VM and updates the instruction pointer
+// Read a single bytecode from the chunk and updates the instruction pointer
 #define READ_BYTE() (*(vm.ip++))
 
+// Read a 24-bit (or 3 bytes) operand from the chunk
 #define READ_LONG_OPERAND()                                                    \
   READ_BYTE() | ((READ_BYTE()) << 8) | ((READ_BYTE()) << 16)
 
@@ -162,7 +187,10 @@ static InterpretResult run() {
 // array
 #define READ_CONSTANT_LONG() (vm.chunk->constants.values[READ_LONG_OPERAND()])
 
+// Read a string from the constants array with an 8-bit offset
 #define READ_STRING() AS_STRING(READ_CONSTANT())
+
+// Read a string from the constants array with a 24-bit offset
 #define READ_STRING_LONG() AS_STRING(READ_CONSTANT_LONG())
 
 // Apply a binary operation based on the two next values at stack and on the


### PR DESCRIPTION
This PR implements [chapter 21](https://craftinginterpreters.com/global-variables.html) of Crafting Interpreters. This codes has some differences from the code described in the book:

- I've added three instructions (`OP_GET_GLOBAL_LONG`, `OP_DEFINE_GLOBAL_LONG`, and `OP_SET_GLOBAL_LONG`) in order to handle more than 256 global variables. These instructions use a 24-bit operand.
- I've changed the method for storing global variables in order to solve the 2nd exercise of the chapter.