### PR TITLE
Chapter 24: Calls and Functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ OBJECTS := $(addprefix $(BUILD_DIR)/$(NAME)/, $(notdir $(SOURCES:.c=.o)))
 build/$(NAME): $(OBJECTS)
 	@ printf "%8s %-40s %s\n" $(CC) $@ "$(CFLAGS)"
 	@ mkdir -p build
-	@ $(CC) $(CFLAGS) -I$(INCLUDE_DIR) $^ -o $@
+	@ $(CC) $(CFLAGS) -I$(INCLUDE_DIR) $^ -o $@ -lm
 
 # Compile object files.
 $(BUILD_DIR)/$(NAME)/%.o: $(SOURCE_DIR)/%.c $(HEADERS)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # Mode configuration.
 ifeq ($(MODE),debug)
-	CFLAGS += -O0 -DDEBUG -g
+	CFLAGS += -O0 -DDEBUG_BYTECODE -DDEBUG_TRACE_EXECUTION -g
 	BUILD_DIR := build/debug
 else
 	CFLAGS += -O3 -flto

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -62,8 +62,8 @@ typedef enum {
                        the stack is false. It also pops the value in the stack*/
   OP_JUMP_IF_FALSE_NP, /**< Jumps to another instruction if the value at the top
                        of the stack is false */
-  OP_LOOP, /**< Unconditionally jumps to a previous instruction in the chunk */
-  OP_CALL,
+  OP_LOOP,  /**< Unconditionally jumps to a previous instruction in the chunk */
+  OP_CALL,  /**< Invokes a function that is currently in the stack */
   OP_RETURN /**< Returns from the current function */
 } OpCode;
 

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -62,7 +62,8 @@ typedef enum {
                        the stack is false. It also pops the value in the stack*/
   OP_JUMP_IF_FALSE_NP, /**< Jumps to another instruction if the value at the top
                        of the stack is false */
-  OP_LOOP,  /**< Unconditionally jumps to a previous instruction in the chunk */
+  OP_LOOP, /**< Unconditionally jumps to a previous instruction in the chunk */
+  OP_CALL,
   OP_RETURN /**< Returns from the current function */
 } OpCode;
 

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -9,12 +9,13 @@
 
 /**
  * \brief Compiles a string of source code into a chunk of bytecode to be
- * executed by the clox virtual machine
+ * executed by the clox virtual machine.
+ *
+ * The compiled chunk is part of a function.
  *
  * \param source Pointer to the source code
- * \param chunk Pointer to the Chunk where the bytecodes must be added
  *
- * \return Boolean value that indicates if the compiling process was successful
+ * \return Pointer to the function that was compiled
  */
 ObjFunction* compile(const char* source);
 

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -16,6 +16,6 @@
  *
  * \return Boolean value that indicates if the compiling process was successful
  */
-bool compile(const char* source, Chunk* chunk);
+ObjFunction* compile(const char* source);
 
 #endif

--- a/include/global.h
+++ b/include/global.h
@@ -37,6 +37,9 @@ typedef struct {
 #define UNDEFINED_GLOBAL(identifier, isConst)                                  \
   ((GlobalVar){identifier, UNDEFINED_VAL, isConst})
 
+#define NEW_GLOBAL(identifier, value, isConst)                                 \
+  ((GlobalVar){identifier, value, isConst})
+
 /**
  * \brief Initializes the resources of a given global values array.
  *

--- a/include/global.h
+++ b/include/global.h
@@ -37,6 +37,10 @@ typedef struct {
 #define UNDEFINED_GLOBAL(identifier, isConst)                                  \
   ((GlobalVar){identifier, UNDEFINED_VAL, isConst})
 
+/**
+ * \def UNDEFINED_GLOBAL(identifier, value isConst)
+ * \brief Helper macro that creates a global variable
+ */
 #define NEW_GLOBAL(identifier, value, isConst)                                 \
   ((GlobalVar){identifier, value, isConst})
 

--- a/include/object.h
+++ b/include/object.h
@@ -15,7 +15,16 @@
  */
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
 
+/**
+ * \def IS_FUNCTION(value)
+ * \brief Helper macro used to determine if a given value is a Lox function
+ */
 #define IS_FUNCTION(value) isObjType(value, OBJ_FUNCTION)
+
+/**
+ * \def IS_NATIVE(value)
+ * \brief Helper macro used to determine if a given value is a native function
+ */
 #define IS_NATIVE(value) isObjType(value, OBJ_NATIVE)
 
 /**
@@ -24,7 +33,16 @@
  */
 #define IS_STRING(value) isObjType(value, OBJ_STRING)
 
+/**
+ * \def AS_FUNCTION(value)
+ * \brief Helper macro used to get an object value as a ObjFunction
+ */
 #define AS_FUNCTION(value) ((ObjFunction*)AS_OBJ(value))
+
+/**
+ * \def AS_NATIVE(value)
+ * \brief Helper macro used to get an object value as a ObjNative
+ */
 #define AS_NATIVE(value) ((ObjNative*)AS_OBJ(value))
 
 /**
@@ -44,9 +62,9 @@
  * \brief Enum for all types of object values
  */
 typedef enum {
-  OBJ_FUNCTION,
-  OBJ_NATIVE,
-  OBJ_STRING, /**< String object */
+  OBJ_FUNCTION, /**< Lox function */
+  OBJ_NATIVE,   /**< Native function */
+  OBJ_STRING,   /**< String object */
 } ObjType;
 
 /**
@@ -58,19 +76,31 @@ struct Obj {
   struct Obj* next; /**< Next object in the linked-list of allocated objects */
 };
 
+/**
+ * \struct ObjFunction
+ * \brief Struct used to represent a Lox bytecode function
+ */
 typedef struct {
-  Obj obj;
-  uint32_t arity;
-  Chunk chunk;
-  ObjString* name;
+  Obj obj;         /**< Obj field needed for "struct inheritance" */
+  uint32_t arity;  /**< Number of parameters that the function expects */
+  Chunk chunk;     /**< Chunk of bytecode associated with the function */
+  ObjString* name; /**< Name of the function, if there is any */
 } ObjFunction;
 
+/**
+ * \var NativeFn
+ * \brief Type definition for a native function that can be called in Lox
+ */
 typedef bool (*NativeFn)(const uint8_t argCount, Value* args);
 
+/**
+ * \struct ObjNative
+ * \brief Struct used to represent a native function
+ */
 typedef struct {
-  Obj obj;
-  uint32_t arity;
-  NativeFn function;
+  Obj obj;           /**< Obj field needed for "struct inheritance" */
+  uint32_t arity;    /**< Number of parameters that the function expects */
+  NativeFn function; /**< Pointer to the C function */
 } ObjNative;
 
 /**
@@ -84,8 +114,22 @@ struct ObjString {
   uint32_t hash; /**< Hash code of the string, needed for use in hash tables */
 };
 
+/**
+ * \brief Creates an empty ObjFunction object.
+ *
+ * \return Pointer to the created ObjFunction
+ */
 ObjFunction* newFunction();
-ObjNative* newNative(NativeFn function, const uint32_t arity);
+
+/**
+ * \brief Creates a new ObjNative object.
+ *
+ * \param function Pointer to the C function
+ * \param arity Expected number of parameters
+ *
+ * \return Pointer to the created ObjNative
+ */
+ObjNative* newNative(const NativeFn function, const uint32_t arity);
 
 /**
  * \brief Allocates an ObjString and takes ownership of an already allocated

--- a/include/object.h
+++ b/include/object.h
@@ -25,7 +25,7 @@
 #define IS_STRING(value) isObjType(value, OBJ_STRING)
 
 #define AS_FUNCTION(value) ((ObjFunction*)AS_OBJ(value))
-#define AS_NATIVE(value) (((ObjNative*)AS_OBJ(value))->function)
+#define AS_NATIVE(value) ((ObjNative*)AS_OBJ(value))
 
 /**
  * \def AS_STRING(value)
@@ -65,10 +65,11 @@ typedef struct {
   ObjString* name;
 } ObjFunction;
 
-typedef Value (*NativeFn)(const uint8_t argCount, const Value* args);
+typedef bool (*NativeFn)(const uint8_t argCount, Value* args);
 
 typedef struct {
   Obj obj;
+  uint32_t arity;
   NativeFn function;
 } ObjNative;
 
@@ -84,7 +85,7 @@ struct ObjString {
 };
 
 ObjFunction* newFunction();
-ObjNative* newNative(NativeFn function);
+ObjNative* newNative(NativeFn function, const uint32_t arity);
 
 /**
  * \brief Allocates an ObjString and takes ownership of an already allocated

--- a/include/object.h
+++ b/include/object.h
@@ -16,6 +16,7 @@
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
 
 #define IS_FUNCTION(value) isObjType(value, OBJ_FUNCTION)
+#define IS_NATIVE(value) isObjType(value, OBJ_NATIVE)
 
 /**
  * \def IS_STRING(value)
@@ -24,6 +25,7 @@
 #define IS_STRING(value) isObjType(value, OBJ_STRING)
 
 #define AS_FUNCTION(value) ((ObjFunction*)AS_OBJ(value))
+#define AS_NATIVE(value) (((ObjNative*)AS_OBJ(value))->function)
 
 /**
  * \def AS_STRING(value)
@@ -43,6 +45,7 @@
  */
 typedef enum {
   OBJ_FUNCTION,
+  OBJ_NATIVE,
   OBJ_STRING, /**< String object */
 } ObjType;
 
@@ -62,6 +65,13 @@ typedef struct {
   ObjString* name;
 } ObjFunction;
 
+typedef Value (*NativeFn)(const uint8_t argCount, const Value* args);
+
+typedef struct {
+  Obj obj;
+  NativeFn function;
+} ObjNative;
+
 /**
  * \struct ObjString
  * \brief Struct used to represent a string object
@@ -74,6 +84,7 @@ struct ObjString {
 };
 
 ObjFunction* newFunction();
+ObjNative* newNative(NativeFn function);
 
 /**
  * \brief Allocates an ObjString and takes ownership of an already allocated

--- a/include/object.h
+++ b/include/object.h
@@ -5,6 +5,7 @@
 #ifndef CLOX_OBJECT_H
 #define CLOX_OBJECT_H
 
+#include "chunk.h"
 #include "common.h"
 #include "value.h"
 
@@ -14,11 +15,15 @@
  */
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
 
+#define IS_FUNCTION(value) isObjType(value, OBJ_FUNCTION)
+
 /**
  * \def IS_STRING(value)
  * \brief Helper macro used to determine if a given value is a string
  */
 #define IS_STRING(value) isObjType(value, OBJ_STRING)
+
+#define AS_FUNCTION(value) ((ObjFunction*)AS_OBJ(value))
 
 /**
  * \def AS_STRING(value)
@@ -37,6 +42,7 @@
  * \brief Enum for all types of object values
  */
 typedef enum {
+  OBJ_FUNCTION,
   OBJ_STRING, /**< String object */
 } ObjType;
 
@@ -49,6 +55,13 @@ struct Obj {
   struct Obj* next; /**< Next object in the linked-list of allocated objects */
 };
 
+typedef struct {
+  Obj obj;
+  uint32_t arity;
+  Chunk chunk;
+  ObjString* name;
+} ObjFunction;
+
 /**
  * \struct ObjString
  * \brief Struct used to represent a string object
@@ -59,6 +72,8 @@ struct ObjString {
   char* chars;   /**< Pointer to the string in the heap */
   uint32_t hash; /**< Hash code of the string, needed for use in hash tables */
 };
+
+ObjFunction* newFunction();
 
 /**
  * \brief Allocates an ObjString and takes ownership of an already allocated

--- a/include/vm.h
+++ b/include/vm.h
@@ -11,6 +11,10 @@
 #include "table.h"
 #include "value.h"
 
+/**
+ * \def FRAMES_MAX
+ * \brief Maximum size of the call stack.
+ */
 #define FRAMES_MAX 64
 
 /**
@@ -19,10 +23,15 @@
  */
 #define STACK_MAX UINT16_COUNT
 
+/**
+ * \struct CallFrame
+ * \brief Represents the call frame of a single ongoing function call
+ */
 typedef struct {
-  ObjFunction* function;
-  uint8_t* ip;
-  Value* slots;
+  ObjFunction* function; /**< Pointer to the called function */
+  uint8_t* ip;           /**< Instruction pointer for the function's chunk */
+  Value* slots; /**< Pointer to the first slot in the value stack that can be
+                   used by the function */
 } CallFrame;
 
 /**
@@ -31,8 +40,8 @@ typedef struct {
  * necessary attributes.
  */
 typedef struct {
-  CallFrame frames[FRAMES_MAX];
-  uint32_t frameCount;
+  CallFrame frames[FRAMES_MAX]; /**< Call stack used to manage function calls */
+  uint32_t frameCount;          /**< Number of ongoing function calls */
   Value stack[STACK_MAX]; /**< Value stack used to manage temporary values */
   Value* stackTop;        /**< Pointer to the top of the stack */
   Table globalNames;      /**< Table of defined global identifiers */

--- a/include/vm.h
+++ b/include/vm.h
@@ -7,8 +7,11 @@
 
 #include "chunk.h"
 #include "global.h"
+#include "object.h"
 #include "table.h"
 #include "value.h"
+
+#define FRAMES_MAX 64
 
 /**
  * \def STACK_MAX
@@ -16,14 +19,20 @@
  */
 #define STACK_MAX UINT16_COUNT
 
+typedef struct {
+  ObjFunction* function;
+  uint8_t* ip;
+  Value* slots;
+} CallFrame;
+
 /**
  * \struct VM
  * \brief Structure that represents the clox virtual machine and contains its
  * necessary attributes.
  */
 typedef struct {
-  Chunk* chunk;           /**< Pointer to the chunk of bytecode instructions */
-  uint8_t* ip;            /**< Pointer to the next instruction to be executed */
+  CallFrame frames[FRAMES_MAX];
+  uint32_t frameCount;
   Value stack[STACK_MAX]; /**< Value stack used to manage temporary values */
   Value* stackTop;        /**< Pointer to the top of the stack */
   Table globalNames;      /**< Table of defined global identifiers */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1194,6 +1194,19 @@ static void printStatement() {
   emitByte(OP_PRINT);
 }
 
+static void returnStatement() {
+  if (current->type == TYPE_SCRIPT)
+    error("Can't return from top-level code.");
+
+  if (match(TOKEN_SEMICOLON)) {
+    emitReturn();
+  } else {
+    expression();
+    consume(TOKEN_SEMICOLON, "Expect ';' after return value.");
+    emitByte(OP_RETURN);
+  }
+}
+
 /**
  * \brief Function used to parse a while statement.
  *
@@ -1273,6 +1286,8 @@ static void statement() {
     forStatement();
   } else if (match(TOKEN_IF)) {
     ifStatement();
+  } else if (match(TOKEN_RETURN)) {
+    returnStatement();
   } else if (match(TOKEN_WHILE)) {
     whileStatement();
   } else if (match(TOKEN_LEFT_BRACE)) {

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef DEBUG
+#ifdef DEBUG_BYTECODE
 #include "debug.h"
 #endif
 
@@ -419,7 +419,7 @@ static ObjFunction* endCompiler() {
   emitReturn();
   ObjFunction* function = current->function;
 
-#ifdef DEBUG
+#ifdef DEBUG_BYTECODE
   if (!parser.hadError) {
     disassembleChunk(currentChunk(), function->name != NULL
                                          ? function->name->chars

--- a/src/debug.c
+++ b/src/debug.c
@@ -252,6 +252,8 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return jumpInstruction("OP_JUMP_IF_FALSE_NP", 1, chunk, offset);
   case OP_LOOP:
     return jumpInstruction("OP_LOOP", -1, chunk, offset);
+  case OP_CALL:
+    return byteInstruction("OP_CALL", chunk, offset);
   case OP_RETURN:
     return simpleInstruction("OP_RETURN", offset);
   default:

--- a/src/memory.c
+++ b/src/memory.c
@@ -28,6 +28,12 @@ void* reallocate(void* pointer, const size_t oldSize, const size_t newSize) {
  */
 static void freeObject(Obj* object) {
   switch (object->type) {
+  case OBJ_FUNCTION: {
+    ObjFunction* function = (ObjFunction*)object;
+    freeChunk(&function->chunk);
+    FREE(ObjFunction, object);
+    break;
+  }
   case OBJ_STRING:
     ObjString* string = (ObjString*)object;
     FREE_ARRAY(char, string->chars, string->length + 1);

--- a/src/memory.c
+++ b/src/memory.c
@@ -34,6 +34,9 @@ static void freeObject(Obj* object) {
     FREE(ObjFunction, object);
     break;
   }
+  case OBJ_NATIVE:
+    FREE(ObjNative, object);
+    break;
   case OBJ_STRING:
     ObjString* string = (ObjString*)object;
     FREE_ARRAY(char, string->chars, string->length + 1);

--- a/src/object.c
+++ b/src/object.c
@@ -45,9 +45,10 @@ ObjFunction* newFunction() {
   return function;
 }
 
-ObjNative* newNative(NativeFn function) {
+ObjNative* newNative(const NativeFn function, const uint32_t arity) {
   ObjNative* native = ALLOCATE_OBJ(ObjNative, OBJ_NATIVE);
   native->function = function;
+  native->arity = arity;
 
   return native;
 }

--- a/src/object.c
+++ b/src/object.c
@@ -119,6 +119,11 @@ ObjString* copyString(const char* chars, const size_t length) {
   return allocateString(heapChars, length, hash);
 }
 
+/**
+ * \brief Auxiliary function used to print a Lox function
+ *
+ * \param function Pointer to the function
+ */
 static void printFunction(ObjFunction* function) {
   if (function->name == NULL) {
     printf("<script>");

--- a/src/object.c
+++ b/src/object.c
@@ -37,6 +37,14 @@ static Obj* allocateObject(const size_t size, const ObjType type) {
   return object;
 }
 
+ObjFunction* newFunction() {
+  ObjFunction* function = ALLOCATE_OBJ(ObjFunction, OBJ_FUNCTION);
+  function->arity = 0;
+  function->name = NULL;
+  initChunk(&function->chunk);
+  return function;
+}
+
 /**
  * \brief Produces the hash code for a given string using the FNV-1a hash
  * function.
@@ -103,8 +111,20 @@ ObjString* copyString(const char* chars, const size_t length) {
   return allocateString(heapChars, length, hash);
 }
 
+static void printFunction(ObjFunction* function) {
+  if (function->name == NULL) {
+    printf("<script>");
+    return;
+  }
+
+  printf("<fn %s>", function->name->chars);
+}
+
 void printObject(const Value value) {
   switch (OBJ_TYPE(value)) {
+  case OBJ_FUNCTION:
+    printFunction(AS_FUNCTION(value));
+    break;
   case OBJ_STRING:
     printf("%s", AS_CSTRING(value));
     break;

--- a/src/object.c
+++ b/src/object.c
@@ -45,6 +45,13 @@ ObjFunction* newFunction() {
   return function;
 }
 
+ObjNative* newNative(NativeFn function) {
+  ObjNative* native = ALLOCATE_OBJ(ObjNative, OBJ_NATIVE);
+  native->function = function;
+
+  return native;
+}
+
 /**
  * \brief Produces the hash code for a given string using the FNV-1a hash
  * function.
@@ -124,6 +131,9 @@ void printObject(const Value value) {
   switch (OBJ_TYPE(value)) {
   case OBJ_FUNCTION:
     printFunction(AS_FUNCTION(value));
+    break;
+  case OBJ_NATIVE:
+    printf("<native fn>");
     break;
   case OBJ_STRING:
     printf("%s", AS_CSTRING(value));

--- a/src/vm.c
+++ b/src/vm.c
@@ -8,7 +8,7 @@
 #include "memory.h"
 #include "object.h"
 
-#ifdef DEBUG
+#ifdef DEBUG_TRACE_EXECUTION
 #include "debug.h"
 #endif
 
@@ -258,13 +258,13 @@ static InterpretResult run() {
     push(valueType(left op right));                                            \
   } while (false)
 
-#ifdef DEBUG
+#ifdef DEBUG_TRACE_EXECUTION
   printf("\n=== execution trace ===");
 #endif
 
   while (true) {
 
-#ifdef DEBUG
+#ifdef DEBUG_TRACE_EXECUTION
     printf("          ");
     for (Value* slot = vm.stack; slot < vm.stackTop; ++slot) {
       printf("[");

--- a/src/vm.c
+++ b/src/vm.c
@@ -15,11 +15,22 @@
 #include <stdarg.h>
 #include <string.h>
 #include <time.h>
+#include <math.h>
 
 VM vm;
 
 static bool clockNative(const uint8_t argCount, Value* args) {
   args[-1] = NUMBER_VAL((double)clock() / CLOCKS_PER_SEC);
+  return true;
+}
+
+static bool sqrtNative(const uint8_t argCount, Value* args) {
+  if (!IS_NUMBER(args[0])) {
+    args[-1] = OBJ_VAL(copyString("Argument must be a number!", 26));
+    return false;
+  }
+
+  args[-1] = NUMBER_VAL(sqrt(AS_NUMBER(args[0])));
   return true;
 }
 
@@ -84,6 +95,7 @@ void initVM() {
   initTable(&vm.strings);
 
   defineNative("clock", clockNative, 0);
+  defineNative("sqrt", sqrtNative, 1);
 }
 
 void freeVM() {

--- a/test/function/stack_trace.lox
+++ b/test/function/stack_trace.lox
@@ -1,0 +1,7 @@
+fun a() { b(); }
+fun b() { c(); }
+fun c() {
+  c("too", "many");
+}
+
+a();


### PR DESCRIPTION
This PR implements [chapter 24](https://craftinginterpreters.com/calls-and-functions.html) of Crafting Interpreters. My implementation has some differences when compared to code from the book:

- In order to solve challenge 1, the code of `run()` was changed to save the IP in a variable with the `register` keyword.
- In order to solve challenges 2 and 3, some changes were made to the implementation of native functions. Namely, they validate the number of arguments that were passed and allow for runtime errors within native functions.
- I added a `sqrt` native function.