### PR TITLE
Chapter 25: Closures

### DIFF
--- a/include/chunk.h
+++ b/include/chunk.h
@@ -39,8 +39,10 @@ typedef enum {
                     8-bit offset */
   OP_SET_GLOBAL_LONG, /**< Updates the value of a defined global variable with a
                          24-bit offset */
+  OP_GET_UPVALUE_SHORT,
   OP_GET_UPVALUE,
   OP_SET_UPVALUE,
+  OP_SET_UPVALUE_SHORT,
   OP_NOT,    /**< Applies logical negation to the value at the top of the stack
               */
   OP_NEGATE, /**< Negates the value at the top of the stack */

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -21,11 +21,11 @@ typedef enum {
   OP_FALSE,         /**< Loads a false boolean value to the stack */
   OP_POP,           /**< Pops a value from the stack */
   OP_GET_LOCAL, /**< Loads a local variable to the stack with an 8-bit offset */
-  OP_GET_LOCAL_LONG, /**< Loads a local variable to the stack with an 24-bit
+  OP_GET_LOCAL_SHORT, /**< Loads a local variable to the stack with an 24-bit
                         offset */
   OP_SET_LOCAL,      /**< Updates the value of a defined local variable with an
                          8-bit offset */
-  OP_SET_LOCAL_LONG, /**< Updates the value of a defined local variable with an
+  OP_SET_LOCAL_SHORT, /**< Updates the value of a defined local variable with an
                     24-bit offset */
   OP_GET_GLOBAL, /**< Loads a global variable to the stack with an 8-bit offset
                   */
@@ -67,6 +67,7 @@ typedef enum {
   OP_LOOP,  /**< Unconditionally jumps to a previous instruction in the chunk */
   OP_CALL,  /**< Invokes a function that is currently in the stack */
   OP_CLOSURE,
+  OP_CLOSURE_LONG,
   OP_CLOSE_UPVALUE,
   OP_RETURN /**< Returns from the current function */
 } OpCode;

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -39,10 +39,9 @@ typedef enum {
                     8-bit offset */
   OP_SET_GLOBAL_LONG, /**< Updates the value of a defined global variable with a
                          24-bit offset */
-  OP_GET_UPVALUE_SHORT,
-  OP_GET_UPVALUE,
-  OP_SET_UPVALUE,
-  OP_SET_UPVALUE_SHORT,
+  OP_GET_UPVALUE,     /**< Loads a local variable through its upvalue */
+  OP_SET_UPVALUE, /**< Updates the value of a local variable through its upvalue
+                   */
   OP_NOT,    /**< Applies logical negation to the value at the top of the stack
               */
   OP_NEGATE, /**< Negates the value at the top of the stack */

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -39,6 +39,8 @@ typedef enum {
                     8-bit offset */
   OP_SET_GLOBAL_LONG, /**< Updates the value of a defined global variable with a
                          24-bit offset */
+  OP_GET_UPVALUE,
+  OP_SET_UPVALUE,
   OP_NOT,    /**< Applies logical negation to the value at the top of the stack
               */
   OP_NEGATE, /**< Negates the value at the top of the stack */
@@ -64,6 +66,7 @@ typedef enum {
                        of the stack is false */
   OP_LOOP,  /**< Unconditionally jumps to a previous instruction in the chunk */
   OP_CALL,  /**< Invokes a function that is currently in the stack */
+  OP_CLOSURE,
   OP_RETURN /**< Returns from the current function */
 } OpCode;
 

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -67,6 +67,7 @@ typedef enum {
   OP_LOOP,  /**< Unconditionally jumps to a previous instruction in the chunk */
   OP_CALL,  /**< Invokes a function that is currently in the stack */
   OP_CLOSURE,
+  OP_CLOSE_UPVALUE,
   OP_RETURN /**< Returns from the current function */
 } OpCode;
 

--- a/include/chunk.h
+++ b/include/chunk.h
@@ -21,12 +21,12 @@ typedef enum {
   OP_FALSE,         /**< Loads a false boolean value to the stack */
   OP_POP,           /**< Pops a value from the stack */
   OP_GET_LOCAL, /**< Loads a local variable to the stack with an 8-bit offset */
-  OP_GET_LOCAL_SHORT, /**< Loads a local variable to the stack with an 24-bit
+  OP_GET_LOCAL_SHORT, /**< Loads a local variable to the stack with a 16-bit
                         offset */
-  OP_SET_LOCAL,      /**< Updates the value of a defined local variable with an
-                         8-bit offset */
-  OP_SET_LOCAL_SHORT, /**< Updates the value of a defined local variable with an
-                    24-bit offset */
+  OP_SET_LOCAL,       /**< Updates the value of a defined local variable with an
+                          8-bit offset */
+  OP_SET_LOCAL_SHORT, /**< Updates the value of a defined local variable with a
+                    16-bit offset */
   OP_GET_GLOBAL, /**< Loads a global variable to the stack with an 8-bit offset
                   */
   OP_GET_GLOBAL_LONG, /**< Loads a global variable to the stack with a 24-bit
@@ -65,12 +65,16 @@ typedef enum {
                        the stack is false. It also pops the value in the stack*/
   OP_JUMP_IF_FALSE_NP, /**< Jumps to another instruction if the value at the top
                        of the stack is false */
-  OP_LOOP,  /**< Unconditionally jumps to a previous instruction in the chunk */
-  OP_CALL,  /**< Invokes a function that is currently in the stack */
-  OP_CLOSURE,
-  OP_CLOSURE_LONG,
-  OP_CLOSE_UPVALUE,
-  OP_RETURN /**< Returns from the current function */
+  OP_LOOP, /**< Unconditionally jumps to a previous instruction in the chunk */
+  OP_CALL, /**< Invokes a function that is currently in the stack */
+  OP_CLOSURE, /**< Defines a closure. It has a variable sized operand, which
+                 depends on the number of upvalues */
+  OP_CLOSURE_LONG,  /**< Defines a closure, while loading it with a 24-bit
+                  offset. It has a variable sized operand, which depends on the
+                  number of upvalues */
+  OP_CLOSE_UPVALUE, /**< Closes all upvalues that appear after a certain point
+                       in the stack */
+  OP_RETURN         /**< Returns from the current function */
 } OpCode;
 
 /**

--- a/include/common.h
+++ b/include/common.h
@@ -16,7 +16,7 @@
  */
 #define UINT24_MAX (UINT32_MAX >> 8)
 
-#define UINT8_COUNT (UINT8_MAX + 1)
+#define UINT10_COUNT ((UINT16_MAX >> 6) + 1)
 
 /**
  * \def UINT16_COUNT

--- a/include/common.h
+++ b/include/common.h
@@ -16,6 +16,8 @@
  */
 #define UINT24_MAX (UINT32_MAX >> 8)
 
+#define UINT8_COUNT (UINT8_MAX + 1)
+
 /**
  * \def UINT16_COUNT
  * \brief Maximum size for an array with 16-bit indexes

--- a/include/common.h
+++ b/include/common.h
@@ -16,7 +16,17 @@
  */
 #define UINT24_MAX (UINT32_MAX >> 8)
 
+/**
+ * \def UINT10_COUNT
+ * \brief Maximum size for an array with 10-bit indexes
+ */
 #define UINT10_COUNT ((UINT16_MAX >> 6) + 1)
+
+/**
+ * \def UINT10_COUNT
+ * \brief Maximum size for an array with 10-bit indexes
+ */
+#define UINT8_COUNT (UINT8_MAX + 1)
 
 /**
  * \def UINT16_COUNT

--- a/include/debug.h
+++ b/include/debug.h
@@ -24,6 +24,6 @@ void disassembleChunk(const Chunk* chunk, const char* name);
  *
  * \return Offset of the next instruction
  */
-size_t disassembleInstruction(const Chunk* chunk, const size_t offset);
+size_t disassembleInstruction(const Chunk* chunk, size_t offset);
 
 #endif

--- a/include/debug.h
+++ b/include/debug.h
@@ -24,6 +24,6 @@ void disassembleChunk(const Chunk* chunk, const char* name);
  *
  * \return Offset of the next instruction
  */
-size_t disassembleInstruction(const Chunk* chunk, size_t offset);
+size_t disassembleInstruction(const Chunk* chunk, const size_t offset);
 
 #endif

--- a/include/object.h
+++ b/include/object.h
@@ -113,6 +113,8 @@ typedef struct {
 typedef struct ObjUpvalue {
   Obj obj;
   Value* location;
+  Value closed;
+  struct ObjUpvalue* next;
 } ObjUpvalue;
 
 typedef struct {

--- a/include/object.h
+++ b/include/object.h
@@ -15,6 +15,10 @@
  */
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
 
+/**
+ * \def IS_CLOSURE(value)
+ * \brief Helper macro used to determine if a given value is a closure
+ */
 #define IS_CLOSURE(value) isObjType(value, OBJ_CLOSURE)
 
 /**
@@ -35,6 +39,10 @@
  */
 #define IS_STRING(value) isObjType(value, OBJ_STRING)
 
+/**
+ * \def AS_CLOSURE(value)
+ * \brief Helper macro used to get an object value as a ObjClosure
+ */
 #define AS_CLOSURE(value) ((ObjClosure*)AS_OBJ(value))
 
 /**
@@ -66,11 +74,11 @@
  * \brief Enum for all types of object values
  */
 typedef enum {
-  OBJ_CLOSURE,
+  OBJ_CLOSURE,  /**< Closure object */
   OBJ_FUNCTION, /**< Lox function */
   OBJ_NATIVE,   /**< Native function */
   OBJ_STRING,   /**< String object */
-  OBJ_UPVALUE
+  OBJ_UPVALUE   /**< Upvalue object */
 } ObjType;
 
 /**
@@ -87,11 +95,11 @@ struct Obj {
  * \brief Struct used to represent a Lox bytecode function
  */
 typedef struct {
-  Obj obj;         /**< Obj field needed for "struct inheritance" */
-  uint32_t arity;  /**< Number of parameters that the function expects */
-  uint16_t upvalueCount;
-  Chunk chunk;     /**< Chunk of bytecode associated with the function */
-  ObjString* name; /**< Name of the function, if there is any */
+  Obj obj;               /**< Obj field needed for "struct inheritance" */
+  uint32_t arity;        /**< Number of parameters that the function expects */
+  uint16_t upvalueCount; /**< Number of upvalues captured by the function */
+  Chunk chunk;           /**< Chunk of bytecode associated with the function */
+  ObjString* name;       /**< Name of the function, if there is any */
 } ObjFunction;
 
 /**
@@ -110,18 +118,31 @@ typedef struct {
   NativeFn function; /**< Pointer to the C function */
 } ObjNative;
 
+/**
+ * \struct ObjUpvalue
+ * \brief Struct used to represent an upvalue. An upvalue refers to a local
+ * variable in an enclosing function, that is captured by a closure.
+ */
 typedef struct ObjUpvalue {
-  Obj obj;
-  Value* location;
-  Value closed;
-  struct ObjUpvalue* next;
+  Obj obj;         /**< Obj field needed for "struct inheritance" */
+  Value* location; /**< Location of the upvalue in memory. It may be in the
+                      stack (if the upvalue is open) or in the upvalue itself
+                      (if it is closed). */
+  Value closed;    /**< Field that stores the upvalue if it is closed */
+  struct ObjUpvalue* next; /**< Pointer to the next upvalue in the intrusive
+                              linked-list of upvalues */
 } ObjUpvalue;
 
+/**
+ * \struct ObjClosure
+ * \brief Struct used to represent a closure.
+ */
 typedef struct {
-  Obj obj;
-  ObjFunction* function;
-  ObjUpvalue** upvalues;
-  uint16_t upvalueCount;
+  Obj obj;               /**< Obj field needed for "struct inheritance" */
+  ObjFunction* function; /**< Pointer to the function object associated with the
+                            closure */
+  ObjUpvalue** upvalues; /**< Array of upvalues captured by the closure */
+  uint16_t upvalueCount; /**< Number of upvalues captured by the closure */
 } ObjClosure;
 
 /**
@@ -135,6 +156,14 @@ struct ObjString {
   uint32_t hash; /**< Hash code of the string, needed for use in hash tables */
 };
 
+/**
+ * \brief Creates an empty ObjClosure object.
+ *
+ * \param function Pointer to the ObjFunction that will be wrapped in the
+ * ObjClosure
+ *
+ * \return Pointer to the created ObjClosure
+ */
 ObjClosure* newClosure(ObjFunction* function);
 
 /**
@@ -182,6 +211,13 @@ ObjString* takeString(char* chars, const size_t length);
  */
 ObjString* copyString(const char* chars, const size_t length);
 
+/**
+ * \brief Creates an empty ObjUpvalue object.
+ *
+ * \param slot Pointer to the slot in the stack where the upvalue resides.
+ *
+ * \return Pointer to the created ObjUpvalue
+ */
 ObjUpvalue* newUpvalue(Value* slot);
 
 /**

--- a/include/vm.h
+++ b/include/vm.h
@@ -28,8 +28,8 @@
  * \brief Represents the call frame of a single ongoing function call
  */
 typedef struct {
-  ObjClosure* closure;
-  uint8_t* ip;           /**< Instruction pointer for the function's chunk */
+  ObjClosure* closure; /**< Pointer to the ObjClosure of the callee function */
+  uint8_t* ip;         /**< Instruction pointer for the function's chunk */
   Value* slots; /**< Pointer to the first slot in the value stack that can be
                    used by the function */
 } CallFrame;
@@ -47,9 +47,10 @@ typedef struct {
   Table globalNames;      /**< Table of defined global identifiers */
   GlobalVarArray globalValues; /**< Array with values of global variables */
   Table strings; /**< Table of allocated strings, used for string interning */
-  ObjUpvalue* openUpvalues;
-  Obj* objects;  /**< Pointer to the head of the linked-list of heap-allocated
-                    objects */
+  ObjUpvalue* openUpvalues; /**< Pointer to the head of the linked-list of open
+                               upvalues */
+  Obj* objects; /**< Pointer to the head of the linked-list of heap-allocated
+                   objects */
 } VM;
 
 /**

--- a/include/vm.h
+++ b/include/vm.h
@@ -47,6 +47,7 @@ typedef struct {
   Table globalNames;      /**< Table of defined global identifiers */
   GlobalVarArray globalValues; /**< Array with values of global variables */
   Table strings; /**< Table of allocated strings, used for string interning */
+  ObjUpvalue* openUpvalues;
   Obj* objects;  /**< Pointer to the head of the linked-list of heap-allocated
                     objects */
 } VM;

--- a/include/vm.h
+++ b/include/vm.h
@@ -28,7 +28,7 @@
  * \brief Represents the call frame of a single ongoing function call
  */
 typedef struct {
-  ObjFunction* function; /**< Pointer to the called function */
+  ObjClosure* closure;
   uint8_t* ip;           /**< Instruction pointer for the function's chunk */
   Value* slots; /**< Pointer to the first slot in the value stack that can be
                    used by the function */

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -109,7 +109,7 @@ typedef struct Compiler {
 
   Local locals[UINT10_COUNT]; /**< Array used to store local variables */
   uint32_t localCount; /**< Current number of local variables in locals */
-  Upvalue upvalues[UINT10_COUNT];
+  Upvalue upvalues[UINT8_COUNT];
   int32_t scopeDepth; /**< Scope depth of the code being compiled */
 } Compiler;
 
@@ -777,15 +777,15 @@ static int32_t resolveLocal(Compiler* compiler, const Token* name,
 
 static uint8_t addUpvalue(Compiler* compiler, const uint8_t index,
                           const bool isLocal) {
-  int16_t upvalueCount = compiler->function->upvalueCount;
+  uint8_t upvalueCount = compiler->function->upvalueCount;
 
-  for (uint16_t i = 0; i < upvalueCount; ++i) {
+  for (uint8_t i = 0; i < upvalueCount; ++i) {
     Upvalue* upvalue = &compiler->upvalues[i];
     if (upvalue->index == index && upvalue->isLocal == isLocal)
       return i;
   }
 
-  if (upvalueCount == UINT10_COUNT) {
+  if (upvalueCount == UINT8_COUNT) {
     error("Too many closure variables in function.");
     return 0;
   }
@@ -796,7 +796,7 @@ static uint8_t addUpvalue(Compiler* compiler, const uint8_t index,
   return compiler->function->upvalueCount++;
 }
 
-static int32_t resolveUpvalue(Compiler* compiler, const Token* name,
+static int16_t resolveUpvalue(Compiler* compiler, const Token* name,
                               bool* isConst) {
   if (compiler->enclosing == NULL)
     return -1;
@@ -804,12 +804,12 @@ static int32_t resolveUpvalue(Compiler* compiler, const Token* name,
   int32_t local = resolveLocal(compiler->enclosing, name, isConst);
   if (local != -1) {
     compiler->enclosing->locals[local].isCaptured = true;
-    return addUpvalue(compiler, (uint8_t)local, true);
+    return (int16_t)addUpvalue(compiler, (uint8_t)local, true);
   }
 
-  int32_t upvalue = resolveUpvalue(compiler->enclosing, name, isConst);
+  int16_t upvalue = resolveUpvalue(compiler->enclosing, name, isConst);
   if (upvalue != -1) {
-    return addUpvalue(compiler, (uint8_t)upvalue, false);
+    return (int16_t)addUpvalue(compiler, (uint8_t)upvalue, false);
   }
 
   return -1;

--- a/src/debug.c
+++ b/src/debug.c
@@ -50,7 +50,7 @@ static size_t byteInstruction(const char* name, const Chunk* chunk,
 
 /**
  * \brief Display an instruction at a given offset along with the instruction's
- * 24-bit operand.
+ * 16-bit operand.
  *
  * \param name Name of the instruction
  * \param chunk Pointer to the chunk of bytecode that contains the instruction
@@ -173,6 +173,16 @@ static size_t globalLongInstruction(const char* name, const Chunk* chunk,
   return offset + 4;
 }
 
+/**
+ * \brief Display an instruction that initializes a closure.
+ *
+ * \param name Name of the instruction
+ * \param chunk Pointer to the chunk of bytecode that contains the instruction
+ * \param closureOffset The offset of the closure in the chunk's constants array
+ * \param offset Offset of the instruction within the bytecode array
+ *
+ * \return Offset of the next instruction
+ */
 static size_t closureInstruction(const char* name, const Chunk* chunk,
                                  const uint32_t closureOffset, size_t offset) {
   printf("%-21s %4d ", name, closureOffset);
@@ -180,9 +190,9 @@ static size_t closureInstruction(const char* name, const Chunk* chunk,
   printf("\n");
 
   ObjFunction* function = AS_FUNCTION(chunk->constants.values[closureOffset]);
-  for (int j = 0; j < function->upvalueCount; j++) {
-    int isLocal = chunk->code[offset++];
-    int index = chunk->code[offset++];
+  for (uint16_t j = 0; j < function->upvalueCount; j++) {
+    uint8_t isLocal = chunk->code[offset++];
+    uint8_t index = chunk->code[offset++];
     printf("%04ld    |                          %s %d\n", offset - 2,
            isLocal ? "local" : "upvalue", index);
   }

--- a/src/debug.c
+++ b/src/debug.c
@@ -237,12 +237,8 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return globalLongInstruction("OP_SET_GLOBAL_LONG", chunk, offset);
   case OP_GET_UPVALUE:
     return byteInstruction("OP_GET_UPVALUE", chunk, offset);
-  case OP_GET_UPVALUE_SHORT:
-    return byteShortInstruction("OP_GET_UPVALUE_SHORT", chunk, offset);
   case OP_SET_UPVALUE:
     return byteInstruction("OP_SET_UPVALUE", chunk, offset);
-  case OP_SET_UPVALUE_SHORT:
-    return byteShortInstruction("OP_SET_UPVALUE_SHORT", chunk, offset);
   case OP_NOT:
     return simpleInstruction("OP_NOT", offset);
   case OP_NEGATE:

--- a/src/debug.c
+++ b/src/debug.c
@@ -237,8 +237,12 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return globalLongInstruction("OP_SET_GLOBAL_LONG", chunk, offset);
   case OP_GET_UPVALUE:
     return byteInstruction("OP_GET_UPVALUE", chunk, offset);
+  case OP_GET_UPVALUE_SHORT:
+    return byteShortInstruction("OP_GET_UPVALUE_SHORT", chunk, offset);
   case OP_SET_UPVALUE:
     return byteInstruction("OP_SET_UPVALUE", chunk, offset);
+  case OP_SET_UPVALUE_SHORT:
+    return byteShortInstruction("OP_SET_UPVALUE_SHORT", chunk, offset);
   case OP_NOT:
     return simpleInstruction("OP_NOT", offset);
   case OP_NEGATE:

--- a/src/debug.c
+++ b/src/debug.c
@@ -277,6 +277,8 @@ size_t disassembleInstruction(const Chunk* chunk, size_t offset) {
 
     return offset;
   }
+  case OP_CLOSE_UPVALUE:
+    return simpleInstruction("OP_CLOSE_UPVALUE", offset);
   case OP_RETURN:
     return simpleInstruction("OP_RETURN", offset);
   default:

--- a/src/memory.c
+++ b/src/memory.c
@@ -28,6 +28,12 @@ void* reallocate(void* pointer, const size_t oldSize, const size_t newSize) {
  */
 static void freeObject(Obj* object) {
   switch (object->type) {
+  case OBJ_CLOSURE: {
+    ObjClosure* closure = (ObjClosure*)object;
+    FREE_ARRAY(ObjUpvalue*, closure->upvalues, closure->upvalueCount);
+    FREE(ObjClosure, object);
+    break;
+  }
   case OBJ_FUNCTION: {
     ObjFunction* function = (ObjFunction*)object;
     freeChunk(&function->chunk);
@@ -37,10 +43,14 @@ static void freeObject(Obj* object) {
   case OBJ_NATIVE:
     FREE(ObjNative, object);
     break;
-  case OBJ_STRING:
+  case OBJ_STRING: {
     ObjString* string = (ObjString*)object;
     FREE_ARRAY(char, string->chars, string->length + 1);
     FREE(ObjString, object);
+    break;
+  }
+  case OBJ_UPVALUE:
+    FREE(ObjUpvalue, object);
     break;
   }
 }

--- a/src/object.c
+++ b/src/object.c
@@ -42,7 +42,7 @@ ObjClosure* newClosure(ObjFunction* function) {
   for (uint16_t i = 0; i < function->upvalueCount; ++i) {
     upvalues[i] = NULL;
   }
-  
+
   ObjClosure* closure = ALLOCATE_OBJ(ObjClosure, OBJ_CLOSURE);
   closure->function = function;
   closure->upvalues = upvalues;

--- a/src/object.c
+++ b/src/object.c
@@ -37,9 +37,23 @@ static Obj* allocateObject(const size_t size, const ObjType type) {
   return object;
 }
 
+ObjClosure* newClosure(ObjFunction* function) {
+  ObjUpvalue** upvalues = ALLOCATE(ObjUpvalue*, function->upvalueCount);
+  for (uint16_t i = 0; i < function->upvalueCount; ++i) {
+    upvalues[i] = NULL;
+  }
+  
+  ObjClosure* closure = ALLOCATE_OBJ(ObjClosure, OBJ_CLOSURE);
+  closure->function = function;
+  closure->upvalues = upvalues;
+  closure->upvalueCount = function->upvalueCount;
+  return closure;
+}
+
 ObjFunction* newFunction() {
   ObjFunction* function = ALLOCATE_OBJ(ObjFunction, OBJ_FUNCTION);
   function->arity = 0;
+  function->upvalueCount = 0;
   function->name = NULL;
   initChunk(&function->chunk);
   return function;
@@ -119,6 +133,13 @@ ObjString* copyString(const char* chars, const size_t length) {
   return allocateString(heapChars, length, hash);
 }
 
+ObjUpvalue* newUpvalue(Value* slot) {
+  ObjUpvalue* upvalue = ALLOCATE_OBJ(ObjUpvalue, OBJ_UPVALUE);
+  upvalue->location = slot;
+
+  return upvalue;
+}
+
 /**
  * \brief Auxiliary function used to print a Lox function
  *
@@ -135,6 +156,9 @@ static void printFunction(ObjFunction* function) {
 
 void printObject(const Value value) {
   switch (OBJ_TYPE(value)) {
+  case OBJ_CLOSURE:
+    printFunction(AS_CLOSURE(value)->function);
+    break;
   case OBJ_FUNCTION:
     printFunction(AS_FUNCTION(value));
     break;
@@ -143,6 +167,9 @@ void printObject(const Value value) {
     break;
   case OBJ_STRING:
     printf("%s", AS_CSTRING(value));
+    break;
+  case OBJ_UPVALUE:
+    printf("upvalue");
     break;
   }
 }

--- a/src/object.c
+++ b/src/object.c
@@ -135,7 +135,9 @@ ObjString* copyString(const char* chars, const size_t length) {
 
 ObjUpvalue* newUpvalue(Value* slot) {
   ObjUpvalue* upvalue = ALLOCATE_OBJ(ObjUpvalue, OBJ_UPVALUE);
+  upvalue->closed = UNDEFINED_VAL;
   upvalue->location = slot;
+  upvalue->next = NULL;
 
   return upvalue;
 }

--- a/src/vm.c
+++ b/src/vm.c
@@ -65,6 +65,7 @@ static bool sqrtNative(const uint8_t argCount, Value* args) {
 static void resetStack() {
   vm.stackTop = vm.stack;
   vm.frameCount = 0;
+  vm.openUpvalues = NULL;
 }
 
 /**
@@ -242,8 +243,36 @@ static bool callValue(const Value callee, const uint8_t argCount) {
 }
 
 static ObjUpvalue* captureUpvalue(Value* local) {
+  ObjUpvalue* prevUpvalue = NULL;
+  ObjUpvalue* upvalue = vm.openUpvalues;
+  while (upvalue != NULL && upvalue->location > local) {
+    prevUpvalue = upvalue;
+    upvalue = upvalue->next;
+  }
+  
+  if (upvalue != NULL && upvalue->location == local)
+    return upvalue;
+
   ObjUpvalue* createdUpvalue = newUpvalue(local);
+  createdUpvalue->next = upvalue;
+
+  if (prevUpvalue == NULL) {
+    vm.openUpvalues = createdUpvalue;
+  } else {
+    prevUpvalue->next = createdUpvalue;
+  }
+
   return createdUpvalue;
+}
+
+static void closeUpvalues(const Value* last) {
+  while (vm.openUpvalues != NULL && vm.openUpvalues->location >= last) {
+    ObjUpvalue* upvalue = vm.openUpvalues;
+    upvalue->closed = *upvalue->location;
+    upvalue->location = &upvalue->closed;
+    vm.openUpvalues = upvalue->next;
+  }
+  
 }
 
 /**
@@ -589,8 +618,14 @@ static InterpretResult run() {
       }
       break;
     }
+    case OP_CLOSE_UPVALUE:
+      closeUpvalues(vm.stackTop - 1);
+      pop();
+      break;
     case OP_RETURN: {
       Value result = pop();
+
+      closeUpvalues(frame->slots);
 
       vm.frameCount--;
       if (vm.frameCount == 0) {

--- a/src/vm.c
+++ b/src/vm.c
@@ -518,18 +518,8 @@ static InterpretResult run() {
       push(*frame->closure->upvalues[slot]->location);
       break;
     }
-    case OP_GET_UPVALUE_SHORT: {
-      uint16_t slot = READ_SHORT();
-      push(*frame->closure->upvalues[slot]->location);
-      break;
-    }
     case OP_SET_UPVALUE: {
       uint8_t slot = READ_BYTE();
-      *frame->closure->upvalues[slot]->location = peek(0);
-      break;
-    }
-    case OP_SET_UPVALUE_SHORT: {
-      uint16_t slot = READ_SHORT();
       *frame->closure->upvalues[slot]->location = peek(0);
       break;
     }

--- a/src/vm.c
+++ b/src/vm.c
@@ -518,8 +518,18 @@ static InterpretResult run() {
       push(*frame->closure->upvalues[slot]->location);
       break;
     }
+    case OP_GET_UPVALUE_SHORT: {
+      uint16_t slot = READ_SHORT();
+      push(*frame->closure->upvalues[slot]->location);
+      break;
+    }
     case OP_SET_UPVALUE: {
       uint8_t slot = READ_BYTE();
+      *frame->closure->upvalues[slot]->location = peek(0);
+      break;
+    }
+    case OP_SET_UPVALUE_SHORT: {
+      uint16_t slot = READ_SHORT();
       *frame->closure->upvalues[slot]->location = peek(0);
       break;
     }


### PR DESCRIPTION
This PR implements [chapter 25](https://craftinginterpreters.com/closures.html) of Crafting Interpreters. In addition to that, I also:
- Added support for a `OP_CLOSURE_LONG` instruction, that allows for a 24-bit offset operand to be used in the globals array.
- Changed the size of the locals array in each Compiler instance from 65536 to 1025. This was needed in order to avoid stack overflows when there were many nested functions. 1025 seems to be a reasonable size. 