### PR TITLE
Chapter 28: Methods and Initializers

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -71,6 +71,7 @@ typedef enum {
                        of the stack is false */
   OP_LOOP, /**< Unconditionally jumps to a previous instruction in the chunk */
   OP_CALL, /**< Invokes a function that is currently in the stack */
+  OP_INVOKE,
   OP_CLOSURE, /**< Defines a closure. It has a variable sized operand, which
                  depends on the number of upvalues */
   OP_CLOSURE_LONG,  /**< Defines a closure, while loading it with a 24-bit
@@ -81,6 +82,7 @@ typedef enum {
   OP_RETURN,        /**< Returns from the current function */
   OP_CLASS,
   OP_CLASS_LONG,
+  OP_METHOD,
 } OpCode;
 
 /**

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -72,6 +72,7 @@ typedef enum {
   OP_LOOP, /**< Unconditionally jumps to a previous instruction in the chunk */
   OP_CALL, /**< Invokes a function that is currently in the stack */
   OP_INVOKE,
+  OP_INVOKE_LONG,
   OP_CLOSURE, /**< Defines a closure. It has a variable sized operand, which
                  depends on the number of upvalues */
   OP_CLOSURE_LONG,  /**< Defines a closure, while loading it with a 24-bit
@@ -83,6 +84,7 @@ typedef enum {
   OP_CLASS,
   OP_CLASS_LONG,
   OP_METHOD,
+  OP_METHOD_LONG,
 } OpCode;
 
 /**

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1032,13 +1032,13 @@ static void dot(const bool canAssign) {
 
   if (canAssign && match(TOKEN_EQUAL)) {
     expression();
-    emitVariableInstruction(OP_SET_PROPERTY, nameOffset, true);
+    emitOffsetOperandInstruction(OP_SET_PROPERTY, nameOffset);
   } else if (match(TOKEN_LEFT_PAREN)) {
     uint8_t argCount = argumentList();
-    emitBytes(OP_INVOKE, nameOffset);
+    emitOffsetOperandInstruction(OP_INVOKE, nameOffset);
     emitByte(argCount);
   } else {
-    emitVariableInstruction(OP_GET_PROPERTY, nameOffset, true);
+    emitOffsetOperandInstruction(OP_GET_PROPERTY, nameOffset);
   }
 }
 
@@ -1282,7 +1282,7 @@ static void method() {
 
   function(type);
 
-  emitBytes(OP_METHOD, nameOffset);
+  emitOffsetOperandInstruction(OP_METHOD, nameOffset);
 }
 
 static void classDeclaration() {
@@ -1292,7 +1292,7 @@ static void classDeclaration() {
   uint32_t nameOffset = identifierConstant(&parser.previous, &flag);
   declareVariable(true);
 
-  emitVariableInstruction(OP_CLASS, nameOffset, true);
+  emitOffsetOperandInstruction(OP_CLASS, nameOffset);
   defineVariable(nameOffset);
 
   ClassCompiler classCompiler;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -101,7 +101,9 @@ typedef struct {
  */
 typedef enum {
   TYPE_FUNCTION, /**< Actual Lox Function */
-  TYPE_SCRIPT    /**< Top-level code, which is represented as a function */
+  TYPE_INITIALIZER,
+  TYPE_METHOD,
+  TYPE_SCRIPT /**< Top-level code, which is represented as a function */
 } FunctionType;
 
 /**
@@ -120,9 +122,14 @@ typedef struct Compiler {
   int32_t scopeDepth;            /**< Scope depth of the code being compiled */
 } Compiler;
 
+typedef struct ClassCompiler {
+  struct ClassCompiler* enclosing;
+} ClassCompiler;
+
 // --------- Module variables ---------
 Parser parser;
 Compiler* current = NULL;
+ClassCompiler* currentClass = NULL;
 // ------------------------------------
 
 /**
@@ -347,7 +354,11 @@ static void emitOffsetOperandInstruction(const uint8_t instruction,
  *
  */
 static void emitReturn() {
-  emitByte(OP_NIL);
+  if (current->type == TYPE_INITIALIZER) {
+    emitBytes(OP_GET_LOCAL, 0);
+  } else {
+    emitByte(OP_NIL);
+  }
   emitByte(OP_RETURN);
 }
 
@@ -427,8 +438,15 @@ static void initCompiler(Compiler* compiler, const FunctionType type) {
   // Claim stack slot 0 for the VM's own internal use
   Local* local = &current->locals[current->localCount++];
   local->depth = 0;
-  local->name.start = "";
-  local->name.length = 0;
+
+  if (type != TYPE_FUNCTION) {
+    local->name.start = "this";
+    local->name.length = 4;
+  } else {
+    local->name.start = "";
+    local->name.length = 0;
+  }
+
   local->isConst = false;
   local->isCaptured = false;
 }
@@ -998,14 +1016,27 @@ static void variable(const bool canAssign) {
   namedVariable(parser.previous, canAssign);
 }
 
+static void this_(const bool canAssign) {
+  if (currentClass == NULL) {
+    error("Can't use 'this' outside of class.");
+    return;
+  }
+
+  variable(false);
+}
+
 static void dot(const bool canAssign) {
   consume(TOKEN_IDENTIFIER, "Expect property name after '.'.");
-  ConstFlag flag = (ConstFlag)false;
+  ConstFlag flag = (ConstFlag) false;
   uint32_t nameOffset = identifierConstant(&parser.previous, &flag);
 
   if (canAssign && match(TOKEN_EQUAL)) {
     expression();
     emitVariableInstruction(OP_SET_PROPERTY, nameOffset, true);
+  } else if (match(TOKEN_LEFT_PAREN)) {
+    uint8_t argCount = argumentList();
+    emitBytes(OP_INVOKE, nameOffset);
+    emitByte(argCount);
   } else {
     emitVariableInstruction(OP_GET_PROPERTY, nameOffset, true);
   }
@@ -1073,7 +1104,7 @@ ParseRule rules[] = {
     [TOKEN_PRINT] = {NULL, NULL, PREC_NONE},
     [TOKEN_RETURN] = {NULL, NULL, PREC_NONE},
     [TOKEN_SUPER] = {NULL, NULL, PREC_NONE},
-    [TOKEN_THIS] = {NULL, NULL, PREC_NONE},
+    [TOKEN_THIS] = {this_, NULL, PREC_NONE},
     [TOKEN_TRUE] = {literal, NULL, PREC_NONE},
     [TOKEN_VAR] = {NULL, NULL, PREC_NONE},
     [TOKEN_WHILE] = {NULL, NULL, PREC_NONE},
@@ -1239,17 +1270,45 @@ static void function(const FunctionType type) {
   }
 }
 
+static void method() {
+  consume(TOKEN_IDENTIFIER, "Expect method name.");
+  ConstFlag flag = (ConstFlag) true;
+  uint32_t nameOffset = identifierConstant(&parser.previous, &flag);
+
+  FunctionType type = TYPE_METHOD;
+  if (parser.previous.length == 4 &&
+      memcmp(parser.previous.start, "init", 4) == 0)
+    type = TYPE_INITIALIZER;
+
+  function(type);
+
+  emitBytes(OP_METHOD, nameOffset);
+}
+
 static void classDeclaration() {
   consume(TOKEN_IDENTIFIER, "Expect class name.");
-  ConstFlag flag = (ConstFlag)true;
+  Token className = parser.previous;
+  ConstFlag flag = (ConstFlag) true;
   uint32_t nameOffset = identifierConstant(&parser.previous, &flag);
   declareVariable(true);
 
   emitVariableInstruction(OP_CLASS, nameOffset, true);
   defineVariable(nameOffset);
 
+  ClassCompiler classCompiler;
+  classCompiler.enclosing = currentClass;
+  currentClass = &classCompiler;
+
+  namedVariable(className, false);
   consume(TOKEN_LEFT_BRACE, "Expect '{' before class body.");
+  while (!check(TOKEN_RIGHT_BRACE) && !check(TOKEN_EOF)) {
+    method();
+  }
+
   consume(TOKEN_RIGHT_BRACE, "Expect '}' after class body.");
+  emitByte(OP_POP);
+
+  currentClass = currentClass->enclosing;
 }
 
 /**
@@ -1399,6 +1458,10 @@ static void returnStatement() {
   if (match(TOKEN_SEMICOLON)) {
     emitReturn();
   } else {
+    if (current->type == TYPE_INITIALIZER) {
+      error("Can't return a value from an initializer.");
+    }
+
     expression();
     consume(TOKEN_SEMICOLON, "Expect ';' after return value.");
     emitByte(OP_RETURN);

--- a/src/debug.c
+++ b/src/debug.c
@@ -138,8 +138,19 @@ static size_t invokeInstruction(const char* name, const Chunk* chunk,
   uint8_t argCount = chunk->code[offset + 2];
   printf("%-21s (%d args) %4d '%s'\n", name, argCount, nameOffset,
          vm.globalValues.vars[nameOffset].identifier->chars);
-  
+
   return offset + 3;
+}
+
+static size_t invokeLongInstruction(const char* name, const Chunk* chunk,
+                                    const size_t offset) {
+  uint8_t nameOffset = (chunk->code[offset + 3] << 16) |
+                       (chunk->code[offset + 2] << 8) | chunk->code[offset + 1];
+  uint8_t argCount = chunk->code[offset + 4];
+  printf("%-21s (%d args) %4d '%s'\n", name, argCount, nameOffset,
+         vm.globalValues.vars[nameOffset].identifier->chars);
+
+  return offset + 5;
 }
 
 /**
@@ -305,6 +316,8 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return byteInstruction("OP_CALL", chunk, offset);
   case OP_INVOKE:
     return invokeInstruction("OP_INVOKE", chunk, offset);
+  case OP_INVOKE_LONG:
+    return invokeLongInstruction("OP_INVOKE_LONG", chunk, offset);
   case OP_CLOSURE: {
     uint8_t closureOffset = chunk->code[offset + 1];
     return closureInstruction("OP_CLOSURE", chunk, (uint32_t)closureOffset,
@@ -327,6 +340,8 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return globalLongInstruction("OP_CLASS", chunk, offset);
   case OP_METHOD:
     return globalInstruction("OP_METHOD", chunk, offset);
+  case OP_METHOD_LONG:
+    return globalLongInstruction("OP_METHOD_LONG", chunk, offset);
   default:
     printf("Unknown opcode %d\n", instruction);
     return offset + 1;

--- a/src/debug.c
+++ b/src/debug.c
@@ -132,6 +132,16 @@ static size_t constantLongInstruction(const char* name, const Chunk* chunk,
   return offset + 4;
 }
 
+static size_t invokeInstruction(const char* name, const Chunk* chunk,
+                                const size_t offset) {
+  uint8_t nameOffset = chunk->code[offset + 1];
+  uint8_t argCount = chunk->code[offset + 2];
+  printf("%-21s (%d args) %4d '%s'\n", name, argCount, nameOffset,
+         vm.globalValues.vars[nameOffset].identifier->chars);
+  
+  return offset + 3;
+}
+
 /**
  * \brief Display an instruction which handles global variables. This
  * instruction has one 8-bit operand.
@@ -293,6 +303,8 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return jumpInstruction("OP_LOOP", -1, chunk, offset);
   case OP_CALL:
     return byteInstruction("OP_CALL", chunk, offset);
+  case OP_INVOKE:
+    return invokeInstruction("OP_INVOKE", chunk, offset);
   case OP_CLOSURE: {
     uint8_t closureOffset = chunk->code[offset + 1];
     return closureInstruction("OP_CLOSURE", chunk, (uint32_t)closureOffset,
@@ -313,6 +325,8 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return globalInstruction("OP_CLASS", chunk, offset);
   case OP_CLASS_LONG:
     return globalLongInstruction("OP_CLASS", chunk, offset);
+  case OP_METHOD:
+    return globalInstruction("OP_METHOD", chunk, offset);
   default:
     printf("Unknown opcode %d\n", instruction);
     return offset + 1;

--- a/src/memory.c
+++ b/src/memory.c
@@ -109,9 +109,16 @@ static void blackenObject(Obj* object) {
 #endif
 
   switch (object->type) {
+  case OBJ_BOUND_METHOD: {
+    ObjBoundMethod* bound = (ObjBoundMethod*)object;
+    markValue(bound->receiver);
+    markObject((Obj*)bound->method);
+    break;
+  }
   case OBJ_CLASS: {
-    ObjClass* class = (ObjClass*)object;
-    markObject((Obj*)class->name);
+    ObjClass* class_ = (ObjClass*)object;
+    markObject((Obj*)class_->name);
+    markTable(&class_->methods);
     break;
   }
   case OBJ_CLOSURE: {
@@ -155,9 +162,15 @@ static void freeObject(Obj* object) {
 #endif
 
   switch (object->type) {
-  case OBJ_CLASS:
+  case OBJ_BOUND_METHOD:
+    FREE(ObjBoundMethod, object);
+    break;
+  case OBJ_CLASS: {
+    ObjClass* class_ = (ObjClass*)object;
+    freeTable(&class_->methods);
     FREE(ObjClass, object);
     break;
+  }
   case OBJ_CLOSURE: {
     ObjClosure* closure = (ObjClosure*)object;
     FREE_ARRAY(ObjUpvalue*, closure->upvalues, closure->upvalueCount);
@@ -218,6 +231,7 @@ static void markRoots() {
   markTable(&vm.globalNames);
   markGlobalVarArray(&vm.globalValues);
   markCompilerRoots();
+  markObject((Obj*)vm.initString);
 }
 
 /**

--- a/src/object.c
+++ b/src/object.c
@@ -43,9 +43,17 @@ static Obj* allocateObject(const size_t size, const ObjType type) {
   return object;
 }
 
+ObjBoundMethod* newBoundMethod(const Value receiver, ObjClosure* method) {
+  ObjBoundMethod* bound = ALLOCATE_OBJ(ObjBoundMethod, OBJ_BOUND_METHOD);
+  bound->receiver = receiver;
+  bound->method = method;
+  return bound;
+}
+
 ObjClass* newClass(ObjString* name) {
   ObjClass* class_ = ALLOCATE_OBJ(ObjClass, OBJ_CLASS);
   class_->name = name;
+  initTable(&class_->methods);
 
   return class_;
 }
@@ -180,6 +188,9 @@ static void printFunction(ObjFunction* function) {
 
 void printObject(const Value value) {
   switch (OBJ_TYPE(value)) {
+  case OBJ_BOUND_METHOD:
+    printFunction(AS_BOUND_METHOD(value)->method->function);
+    break;
   case OBJ_CLASS:
     printf("%s", AS_CLASS(value)->name->chars);
     break;

--- a/src/object.c
+++ b/src/object.c
@@ -53,6 +53,7 @@ ObjBoundMethod* newBoundMethod(const Value receiver, ObjClosure* method) {
 ObjClass* newClass(ObjString* name) {
   ObjClass* class_ = ALLOCATE_OBJ(ObjClass, OBJ_CLASS);
   class_->name = name;
+  class_->initializer = UNDEFINED_VAL;
   initTable(&class_->methods);
 
   return class_;

--- a/src/object.h
+++ b/src/object.h
@@ -165,6 +165,7 @@ typedef struct {
   Obj obj;
   ObjString* name;
   Table methods;
+  Value initializer;
 } ObjClass;
 
 typedef struct {

--- a/src/object.h
+++ b/src/object.h
@@ -16,6 +16,7 @@
  */
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
 
+#define IS_BOUND_METHOD(value) isObjType(value, OBJ_BOUND_METHOD)
 #define IS_CLASS(value) isObjType(value, OBJ_CLASS)
 
 /**
@@ -44,6 +45,7 @@
  */
 #define IS_STRING(value) isObjType(value, OBJ_STRING)
 
+#define AS_BOUND_METHOD(value) ((ObjBoundMethod*)AS_OBJ(value))
 #define AS_CLASS(value) ((ObjClass*)AS_OBJ(value))
 
 /**
@@ -83,6 +85,7 @@
  * \brief Enum for all types of object values
  */
 typedef enum {
+  OBJ_BOUND_METHOD,
   OBJ_CLASS,
   OBJ_CLOSURE,  /**< Closure object */
   OBJ_FUNCTION, /**< Lox function */
@@ -161,6 +164,7 @@ typedef struct {
 typedef struct {
   Obj obj;
   ObjString* name;
+  Table methods;
 } ObjClass;
 
 typedef struct {
@@ -168,6 +172,12 @@ typedef struct {
   ObjClass* class_;
   Table fields;
 } ObjInstance;
+
+typedef struct {
+  Obj obj;
+  Value receiver;
+  ObjClosure* method;
+} ObjBoundMethod;
 
 /**
  * \struct ObjString
@@ -179,6 +189,8 @@ struct ObjString {
   char* chars;   /**< Pointer to the string in the heap */
   uint32_t hash; /**< Hash code of the string, needed for use in hash tables */
 };
+
+ObjBoundMethod* newBoundMethod(Value receiver, ObjClosure* method);
 
 ObjClass* newClass(ObjString* name);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -826,6 +826,17 @@ static InterpretResult run() {
       ip = frame->ip;
       break;
     }
+    case OP_INVOKE_LONG: {
+      ObjString* method = vm.globalValues.vars[READ_LONG_OPERAND()].identifier;
+      uint8_t argCount = READ_BYTE();
+
+      frame->ip = ip;
+      if (!invoke(method, argCount))
+        return INTERPRET_RUNTIME_ERROR;
+      frame = &vm.frames[vm.frameCount - 1];
+      ip = frame->ip;
+      break;
+    }
     case OP_CLOSURE:
       ip = defineClosure(AS_FUNCTION(READ_CONSTANT()), frame, ip);
       break;
@@ -863,6 +874,9 @@ static InterpretResult run() {
       break;
     case OP_METHOD:
       defineMethod(vm.globalValues.vars[READ_BYTE()].identifier);
+      break;
+    case OP_METHOD_LONG:
+      defineMethod(vm.globalValues.vars[READ_LONG_OPERAND()].identifier);
       break;
     default:
       break;

--- a/src/vm.c
+++ b/src/vm.c
@@ -268,9 +268,8 @@ static bool callValue(const Value callee, const uint8_t argCount) {
     case OBJ_CLASS: {
       ObjClass* class_ = AS_CLASS(callee);
       vm.stackTop[-argCount - 1] = OBJ_VAL(newInstance(class_));
-      Value initializer;
-      if (tableGet(&class_->methods, vm.initString, &initializer)) {
-        return call(AS_CLOSURE(initializer), argCount);
+      if (!IS_UNDEFINED(class_->initializer)) {
+        return call(AS_CLOSURE(class_->initializer), argCount);
       } else if (argCount != 0) {
         runtimeError("Expected 0 arguments but got %d.", argCount);
         return false;
@@ -394,6 +393,8 @@ static void defineMethod(ObjString* name) {
   Value method = peek(0);
   ObjClass* class_ = AS_CLASS(peek(1));
   tableSet(&class_->methods, name, method);
+  if (name == vm.initString)
+    class_->initializer = method;
   pop();
 }
 

--- a/src/vm.h
+++ b/src/vm.h
@@ -47,6 +47,7 @@ typedef struct {
   Table globalNames;      /**< Table of defined global identifiers */
   GlobalVarArray globalValues; /**< Array with values of global variables */
   Table strings; /**< Table of allocated strings, used for string interning */
+  ObjString* initString;
   ObjUpvalue* openUpvalues; /**< Pointer to the head of the linked-list of open
                                upvalues */
   size_t bytesAllocated; /**< Number of bytes of managed memory allocated by the


### PR DESCRIPTION
This PR implements [chapter 28](https://craftinginterpreters.com/methods-and-initializers.html) of Crafting Interpreters. In addition to that, I also:

- Added _LONG versions for method instructions (OP_INVOKE AND OP_METHOD). These instructions were also implemented in a slightly different way from the book due to how I implemented global variables.
- Implemented a caching for cache initializers in order to solve challenge 1.