### PR TITLE
Chapter 29: Superclasses

### DIFF
--- a/src/chunk.h
+++ b/src/chunk.h
@@ -42,12 +42,16 @@ typedef enum {
   OP_GET_UPVALUE,     /**< Loads a local variable through its upvalue */
   OP_SET_UPVALUE, /**< Updates the value of a local variable through its upvalue
                    */
-  OP_GET_PROPERTY,
-  OP_GET_PROPERTY_LONG,
-  OP_SET_PROPERTY,
-  OP_SET_PROPERTY_LONG,
-  OP_GET_SUPER,
-  OP_GET_SUPER_LONG,
+  OP_GET_PROPERTY, /**< Loads a property from a class instance using an 8-bit
+                      offset */
+  OP_GET_PROPERTY_LONG, /**< Loads a property from a class instance using a
+                           24-bit offset */
+  OP_SET_PROPERTY, /**< Sets the value of a property for a class instance using
+                      an 8-bit offset */
+  OP_SET_PROPERTY_LONG, /**< Sets the value of a property for a class instance
+                           using a 24-bit offset */
+  OP_GET_SUPER,      /**< Loads a method from "super" using an 8-bit offset */
+  OP_GET_SUPER_LONG, /**< Loads a method from "super" using a 24-bit offset */
   OP_NOT,    /**< Applies logical negation to the value at the top of the stack
               */
   OP_NEGATE, /**< Negates the value at the top of the stack */
@@ -73,10 +77,14 @@ typedef enum {
                        of the stack is false */
   OP_LOOP, /**< Unconditionally jumps to a previous instruction in the chunk */
   OP_CALL, /**< Invokes a function that is currently in the stack */
-  OP_INVOKE,
-  OP_INVOKE_LONG,
-  OP_SUPER_INVOKE,
-  OP_SUPER_INVOKE_LONG,
+  OP_INVOKE, /**< Superinstruction which loads a class method and invokes it.
+                Uses an 8-bit offset */
+  OP_INVOKE_LONG,  /**< Superinstruction which loads a class method and invokes
+                      it. Uses a 24-bit offset */
+  OP_SUPER_INVOKE, /**< Superinstruction which loads property from "super" and
+                      immediately invokes it. Uses an 8-bit offset */
+  OP_SUPER_INVOKE_LONG, /**< Superinstruction which loads property from "super" and
+                      immediately invokes it. Uses a 24-bit offset */
   OP_CLOSURE, /**< Defines a closure. It has a variable sized operand, which
                  depends on the number of upvalues */
   OP_CLOSURE_LONG,  /**< Defines a closure, while loading it with a 24-bit
@@ -85,11 +93,15 @@ typedef enum {
   OP_CLOSE_UPVALUE, /**< Closes all upvalues that appear after a certain point
                        in the stack */
   OP_RETURN,        /**< Returns from the current function */
-  OP_CLASS,
-  OP_CLASS_LONG,
+  OP_CLASS, /**< Creates a new class object and pushes it to the stack. Uses an
+               8-bit offset */
+  OP_CLASS_LONG, /**< Creates a new class object and pushes it to the stack.
+                    Uses a 24-bit offset */
   OP_INHERIT,
-  OP_METHOD,
-  OP_METHOD_LONG,
+  OP_METHOD, /**< Adds a method to the method table of a class. Uses an 8-bit
+                offset  */
+  OP_METHOD_LONG, /**< Adds a method to the method table of a class. Uses a
+                     24-bit offset  */
 } OpCode;
 
 /**

--- a/src/chunk.h
+++ b/src/chunk.h
@@ -46,6 +46,8 @@ typedef enum {
   OP_GET_PROPERTY_LONG,
   OP_SET_PROPERTY,
   OP_SET_PROPERTY_LONG,
+  OP_GET_SUPER,
+  OP_GET_SUPER_LONG,
   OP_NOT,    /**< Applies logical negation to the value at the top of the stack
               */
   OP_NEGATE, /**< Negates the value at the top of the stack */
@@ -73,6 +75,8 @@ typedef enum {
   OP_CALL, /**< Invokes a function that is currently in the stack */
   OP_INVOKE,
   OP_INVOKE_LONG,
+  OP_SUPER_INVOKE,
+  OP_SUPER_INVOKE_LONG,
   OP_CLOSURE, /**< Defines a closure. It has a variable sized operand, which
                  depends on the number of upvalues */
   OP_CLOSURE_LONG,  /**< Defines a closure, while loading it with a 24-bit
@@ -83,6 +87,7 @@ typedef enum {
   OP_RETURN,        /**< Returns from the current function */
   OP_CLASS,
   OP_CLASS_LONG,
+  OP_INHERIT,
   OP_METHOD,
   OP_METHOD_LONG,
 } OpCode;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -124,6 +124,7 @@ typedef struct Compiler {
 
 typedef struct ClassCompiler {
   struct ClassCompiler* enclosing;
+  bool hasSuperclass;
 } ClassCompiler;
 
 // --------- Module variables ---------
@@ -1016,6 +1017,39 @@ static void variable(const bool canAssign) {
   namedVariable(parser.previous, canAssign);
 }
 
+static Token syntheticToken(const char* text) {
+  Token token;
+  token.start = text;
+  token.length = strlen(text);
+  return token;
+}
+
+static void super_(const bool canAssign) {
+  if (currentClass == NULL) {
+    error("Can't use 'super' outside of class.");
+  } else if (!currentClass->hasSuperclass) {
+    error("Can't use 'super' in a class with no superclass");
+  }
+
+  consume(TOKEN_DOT, "Expect '.' after 'super'.");
+  consume(TOKEN_IDENTIFIER, "Expect superclass method name.");
+
+  ConstFlag flag = (ConstFlag) true;
+  uint32_t nameOffset = identifierConstant(&parser.previous, &flag);
+
+  namedVariable(syntheticToken("this"), false);
+
+  if (match(TOKEN_LEFT_PAREN)) {
+    uint8_t argCount = argumentList();
+    namedVariable(syntheticToken("super"), false);
+    emitOffsetOperandInstruction(OP_SUPER_INVOKE, nameOffset);
+    emitByte(argCount);
+  } else {
+    namedVariable(syntheticToken("super"), false);
+    emitOffsetOperandInstruction(OP_GET_SUPER, nameOffset);
+  }
+}
+
 static void this_(const bool canAssign) {
   if (currentClass == NULL) {
     error("Can't use 'this' outside of class.");
@@ -1103,7 +1137,7 @@ ParseRule rules[] = {
     [TOKEN_OR] = {NULL, or_, PREC_OR},
     [TOKEN_PRINT] = {NULL, NULL, PREC_NONE},
     [TOKEN_RETURN] = {NULL, NULL, PREC_NONE},
-    [TOKEN_SUPER] = {NULL, NULL, PREC_NONE},
+    [TOKEN_SUPER] = {super_, NULL, PREC_NONE},
     [TOKEN_THIS] = {this_, NULL, PREC_NONE},
     [TOKEN_TRUE] = {literal, NULL, PREC_NONE},
     [TOKEN_VAR] = {NULL, NULL, PREC_NONE},
@@ -1296,8 +1330,25 @@ static void classDeclaration() {
   defineVariable(nameOffset);
 
   ClassCompiler classCompiler;
+  classCompiler.hasSuperclass = false;
   classCompiler.enclosing = currentClass;
   currentClass = &classCompiler;
+
+  if (match(TOKEN_LESS)) {
+    consume(TOKEN_IDENTIFIER, "Expect superclass name.");
+    variable(false);
+
+    if (identifiersEqual(&className, &parser.previous))
+      error("A class can't inherit from itself.");
+
+    beginScope();
+    addLocal(syntheticToken("super"), true);
+    defineVariable(0);
+
+    namedVariable(className, false);
+    emitByte(OP_INHERIT);
+    classCompiler.hasSuperclass = true;
+  }
 
   namedVariable(className, false);
   consume(TOKEN_LEFT_BRACE, "Expect '{' before class body.");
@@ -1307,6 +1358,10 @@ static void classDeclaration() {
 
   consume(TOKEN_RIGHT_BRACE, "Expect '}' after class body.");
   emitByte(OP_POP);
+
+  if (classCompiler.hasSuperclass) {
+    endScope();
+  }
 
   currentClass = currentClass->enclosing;
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -144,7 +144,7 @@ static size_t invokeInstruction(const char* name, const Chunk* chunk,
 
 static size_t invokeLongInstruction(const char* name, const Chunk* chunk,
                                     const size_t offset) {
-  uint8_t nameOffset = (chunk->code[offset + 3] << 16) |
+  uint32_t nameOffset = (chunk->code[offset + 3] << 16) |
                        (chunk->code[offset + 2] << 8) | chunk->code[offset + 1];
   uint8_t argCount = chunk->code[offset + 4];
   printf("%-21s (%d args) %4d '%s'\n", name, argCount, nameOffset,
@@ -278,6 +278,10 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return globalInstruction("OP_SET_PROPERTY", chunk, offset);
   case OP_SET_PROPERTY_LONG:
     return globalLongInstruction("OP_SET_PROPERTY_LONG", chunk, offset);
+  case OP_GET_SUPER:
+    return globalInstruction("OP_GET_SUPER", chunk, offset);
+  case OP_GET_SUPER_LONG:
+    return globalLongInstruction("OP_GET_SUPER_LONG", chunk, offset);
   case OP_NOT:
     return simpleInstruction("OP_NOT", offset);
   case OP_NEGATE:
@@ -318,6 +322,10 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return invokeInstruction("OP_INVOKE", chunk, offset);
   case OP_INVOKE_LONG:
     return invokeLongInstruction("OP_INVOKE_LONG", chunk, offset);
+  case OP_SUPER_INVOKE:
+    return invokeInstruction("OP_SUPER_INVOKE", chunk, offset);
+  case OP_SUPER_INVOKE_LONG:
+    return invokeLongInstruction("OP_SUPER_INVOKE_LONG", chunk, offset);
   case OP_CLOSURE: {
     uint8_t closureOffset = chunk->code[offset + 1];
     return closureInstruction("OP_CLOSURE", chunk, (uint32_t)closureOffset,
@@ -338,6 +346,8 @@ size_t disassembleInstruction(const Chunk* chunk, const size_t offset) {
     return globalInstruction("OP_CLASS", chunk, offset);
   case OP_CLASS_LONG:
     return globalLongInstruction("OP_CLASS", chunk, offset);
+  case OP_INHERIT:
+    return simpleInstruction("OP_INHERIT", offset);
   case OP_METHOD:
     return globalInstruction("OP_METHOD", chunk, offset);
   case OP_METHOD_LONG:

--- a/src/debug.c
+++ b/src/debug.c
@@ -88,7 +88,7 @@ static size_t jumpInstruction(const char* name, const int8_t sign,
 }
 
 /**
- * \brief Display an OP_CONSTANT instruction at a given offset. This instruction
+ * \brief Display an instruction which use the constants array. This instruction
  * has one 8-bit operand.
  *
  * \param name Name of the instruction
@@ -109,8 +109,8 @@ static size_t constantInstruction(const char* name, const Chunk* chunk,
 }
 
 /**
- * \brief Display an OP_CONSTANT_LONG instruction at a given offset. This
- * instruction has three 8-bit operands.
+ * \brief Display an instruction which use the constants array. This instruction
+ * has three 8-bit operands.
  *
  * \param name Name of the instruction
  * \param chunk Pointer to the chunk of bytecode that contains the instruction
@@ -132,6 +132,16 @@ static size_t constantLongInstruction(const char* name, const Chunk* chunk,
   return offset + 4;
 }
 
+/**
+ * \brief Display a OP_INVOKE or OP_SUPER_INVOKE instruction at a given offset.
+ * This instruction has one 8-bit operand.
+ *
+ * \param name Name of the instruction
+ * \param chunk Pointer to the chunk of bytecode that contains the instruction
+ * \param offset Offset of the instruction within the bytecode array
+ *
+ * \return Offset of the next instruction
+ */
 static size_t invokeInstruction(const char* name, const Chunk* chunk,
                                 const size_t offset) {
   uint8_t nameOffset = chunk->code[offset + 1];
@@ -142,10 +152,21 @@ static size_t invokeInstruction(const char* name, const Chunk* chunk,
   return offset + 3;
 }
 
+/**
+ * \brief Display a OP_INVOKE_LONG or OP_SUPER_INVOKE_LONG instruction at a
+ * given offset. This instruction has three 8-bit operands.
+ *
+ * \param name Name of the instruction
+ * \param chunk Pointer to the chunk of bytecode that contains the instruction
+ * \param offset Offset of the instruction within the bytecode array
+ *
+ * \return Offset of the next instruction
+ */
 static size_t invokeLongInstruction(const char* name, const Chunk* chunk,
                                     const size_t offset) {
   uint32_t nameOffset = (chunk->code[offset + 3] << 16) |
-                       (chunk->code[offset + 2] << 8) | chunk->code[offset + 1];
+                        (chunk->code[offset + 2] << 8) |
+                        chunk->code[offset + 1];
   uint8_t argCount = chunk->code[offset + 4];
   printf("%-21s (%d args) %4d '%s'\n", name, argCount, nameOffset,
          vm.globalValues.vars[nameOffset].identifier->chars);

--- a/src/object.h
+++ b/src/object.h
@@ -16,7 +16,16 @@
  */
 #define OBJ_TYPE(value) (AS_OBJ(value)->type)
 
+/**
+ * \def IS_BOUND_METHOD(value)
+ * \brief Helper macro used to determine if a given value is a bound method
+ */
 #define IS_BOUND_METHOD(value) isObjType(value, OBJ_BOUND_METHOD)
+
+/**
+ * \def IS_CLASS(value)
+ * \brief Helper macro used to determine if a given value is a class object
+ */
 #define IS_CLASS(value) isObjType(value, OBJ_CLASS)
 
 /**
@@ -31,6 +40,10 @@
  */
 #define IS_FUNCTION(value) isObjType(value, OBJ_FUNCTION)
 
+/**
+ * \def IS_INSTANCE(value)
+ * \brief Helper macro used to determine if a given value is a class instance
+ */
 #define IS_INSTANCE(value) isObjType(value, OBJ_INSTANCE)
 
 /**
@@ -45,7 +58,16 @@
  */
 #define IS_STRING(value) isObjType(value, OBJ_STRING)
 
+/**
+ * \def AS_BOUND_METHOD(value)
+ * \brief Helper macro used to get an object value as a ObjBoundMethod
+ */
 #define AS_BOUND_METHOD(value) ((ObjBoundMethod*)AS_OBJ(value))
+
+/**
+ * \def AS_CLASS(value)
+ * \brief Helper macro used to get an object value as a ObjClass
+ */
 #define AS_CLASS(value) ((ObjClass*)AS_OBJ(value))
 
 /**
@@ -60,6 +82,10 @@
  */
 #define AS_FUNCTION(value) ((ObjFunction*)AS_OBJ(value))
 
+/**
+ * \def AS_INSTANCE(value)
+ * \brief Helper macro used to get an object value as a ObjInstance
+ */
 #define AS_INSTANCE(value) ((ObjInstance*)AS_OBJ(value))
 
 /**
@@ -85,14 +111,14 @@
  * \brief Enum for all types of object values
  */
 typedef enum {
-  OBJ_BOUND_METHOD,
-  OBJ_CLASS,
-  OBJ_CLOSURE,  /**< Closure object */
-  OBJ_FUNCTION, /**< Lox function */
-  OBJ_INSTANCE,
-  OBJ_NATIVE,   /**< Native function */
-  OBJ_STRING,   /**< String object */
-  OBJ_UPVALUE   /**< Upvalue object */
+  OBJ_BOUND_METHOD, /**< "Bound method" function object */
+  OBJ_CLASS,        /**< Class object */
+  OBJ_CLOSURE,      /**< Closure object */
+  OBJ_FUNCTION,     /**< Lox function */
+  OBJ_INSTANCE,     /**< Class instance object */
+  OBJ_NATIVE,       /**< Native function */
+  OBJ_STRING,       /**< String object */
+  OBJ_UPVALUE       /**< Upvalue object */
 } ObjType;
 
 /**
@@ -161,23 +187,37 @@ typedef struct {
   uint16_t upvalueCount; /**< Number of upvalues captured by the closure */
 } ObjClosure;
 
+/**
+ * \struct ObjClass
+ * \brief Struct used to represent a class.
+ */
 typedef struct {
-  Obj obj;
-  ObjString* name;
-  Table methods;
-  Value initializer;
+  Obj obj;           /**< Obj field needed for "struct inheritance" */
+  ObjString* name;   /**< Name of the class */
+  Table methods;     /**< Hash table of the class' methods */
+  Value initializer; /**< Value used to cache the class' initializer */
 } ObjClass;
 
+/**
+ * \struct ObjInstance
+ * \brief Struct used to represent a class instance.
+ */
 typedef struct {
-  Obj obj;
-  ObjClass* class_;
-  Table fields;
+  Obj obj;          /**< Obj field needed for "struct inheritance" */
+  ObjClass* class_; /**< Pointer to the instance's class */
+  Table fields;     /**< Hash table of the instance's fields. Fields in Lox are
+                       associated with the instance, not with the class */
 } ObjInstance;
 
+/**
+ * \struct ObjBoundMethod
+ * \brief Struct used to represent a "bound method" object. A bound method is
+ * created when the user executes a method access and saves it in a variable.
+ */
 typedef struct {
-  Obj obj;
-  Value receiver;
-  ObjClosure* method;
+  Obj obj;            /**< Obj field needed for "struct inheritance" */
+  Value receiver;     /**< Class instance associated with this method */
+  ObjClosure* method; /**< Pointer to the method's closure */
 } ObjBoundMethod;
 
 /**
@@ -191,8 +231,23 @@ struct ObjString {
   uint32_t hash; /**< Hash code of the string, needed for use in hash tables */
 };
 
+/**
+ * \brief Creates an empty ObjBoundMethod object.
+ *
+ * \param receiver The method's receiver
+ * \param method Pointer to the method's closure
+ *
+ * \return Pointer to the created ObjBoundMethod
+ */
 ObjBoundMethod* newBoundMethod(Value receiver, ObjClosure* method);
 
+/**
+ * \brief Creates an empty ObjClass object.
+ *
+ * \param name Name of the class
+ *
+ * \return Pointer to the created ObjClass
+ */
 ObjClass* newClass(ObjString* name);
 
 /**
@@ -212,6 +267,13 @@ ObjClosure* newClosure(ObjFunction* function);
  */
 ObjFunction* newFunction();
 
+/**
+ * \brief Creates an empty ObjInstance object.
+ *
+ * \param class_ Pointer to the instance's class
+ *
+ * \return Pointer to the created ObjInstance
+ */
 ObjInstance* newInstance(ObjClass* class_);
 
 /**

--- a/src/vm.h
+++ b/src/vm.h
@@ -47,7 +47,8 @@ typedef struct {
   Table globalNames;      /**< Table of defined global identifiers */
   GlobalVarArray globalValues; /**< Array with values of global variables */
   Table strings; /**< Table of allocated strings, used for string interning */
-  ObjString* initString;
+  ObjString* initString; /**< ObjString used to represent "init". This is needed
+                            to take advantage of string interning  */
   ObjUpvalue* openUpvalues; /**< Pointer to the head of the linked-list of open
                                upvalues */
   size_t bytesAllocated; /**< Number of bytes of managed memory allocated by the
@@ -55,7 +56,7 @@ typedef struct {
   size_t nextGC;         /**< Threshold to trigger a garbage collection */
   Obj* objects; /**< Pointer to the head of the linked-list of heap-allocated
                    objects */
-  size_t grayCount; /**< Number of objects in the gray stack */
+  size_t grayCount;    /**< Number of objects in the gray stack */
   size_t grayCapacity; /**< Capacity of the gray stack */
   Obj** grayStack; /**< Stack of "gray" memory objects, meaning that they are
                       reachable in memory and may reference other objects */


### PR DESCRIPTION
This PR implements [chapter 29](https://craftinginterpreters.com/superclasses.html) of Crafting Interpreters. In addition to that, I also:

- Added _LONG versions for new instructions which have operands (OP_GET_SUPER and OP_SUPER_INVOKE). These instructions were also implemented in a slightly different way from the book due to how I implemented global variables.